### PR TITLE
Initial support for Parkland/TypeID 39 shades

### DIFF
--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -50,6 +50,7 @@ SHADE_TYPE: Final[dict[int, str]] = {
     8: "Duette, Top Down Bottom Up",
     9: "Duette DuoLite, Top Down Bottom Up",
     33: "Duette Architella, Top Down Bottom Up",
+    39: "Parkland",
     47: "Pleated, Top Down Bottom Up",
     # top down, tilt anywhere
     51: "Venetian, Tilt Anywhere",

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -24,6 +24,7 @@ from .api import CLOSED_POSITION, OPEN_POSITION
 from .const import DOMAIN, HOME_KEY, LOGGER
 from .coordinator import PVCoordinator
 
+TILT_ONLY_OPENCLOSED_THRESHOLD = 5
 
 async def async_setup_entry(
     _hass: HomeAssistant,
@@ -33,11 +34,16 @@ async def async_setup_entry(
     """Set up the demo cover platform."""
 
     coordinator: PVCoordinator = config_entry.runtime_data
-    async_add_entities(
-        [PowerViewCoverTilt(coordinator)]
-        if coordinator.dev_details.get("model") in ["51", "62"]
-        else [PowerViewCover(coordinator)]
-    )
+    model: str = coordinator.dev_details.get("model")
+    entites: list[PowerViewCover] = []
+    if model in ["39"]:
+        entites.append(PowerViewCoverTiltOnly(coordinator))
+    elif model in ["51", "62"]:
+        entites.append(PowerViewCoverTilt(coordinator))
+    else:
+        entites.append(PowerViewCover(coordinator))
+
+    async_add_entities(entites)
 
 
 class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEntity):  # type: ignore[reportIncompatibleVariableOverride]
@@ -248,3 +254,41 @@ class PowerViewCoverTilt(PowerViewCover):
         LOGGER.debug("close cover tilt")
         _kwargs = {**kwargs, ATTR_TILT_POSITION: CLOSED_POSITION}
         await self.async_set_cover_tilt_position(**_kwargs)
+
+class PowerViewCoverTiltOnly(PowerViewCoverTilt):
+    """Representation of a PowerView shade with additional tilt functionality."""
+
+    _attr_device_class = CoverDeviceClass.BLIND
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN_TILT
+        | CoverEntityFeature.CLOSE_TILT
+        | CoverEntityFeature.STOP_TILT
+        | CoverEntityFeature.SET_TILT_POSITION
+    )
+
+    def __init__(
+        self,
+        coordinator: PVCoordinator,
+    ) -> None:
+        LOGGER.debug("%s: init() PowerViewCoverTiltOnly", coordinator.name)
+        super().__init__(coordinator)
+
+    @property
+    def is_opening(self) -> bool | None:  # type: ignore[reportIncompatibleVariableOverride]
+        """Return if the cover is opening or not."""
+        return False
+
+    @property
+    def is_closing(self) -> bool | None:  # type: ignore[reportIncompatibleVariableOverride]
+        """Return if the cover is closing or not."""
+        return False
+
+    @property
+    def is_closed(self) -> bool:  # type: ignore[reportIncompatibleVariableOverride]
+        """Return if the cover is closed."""
+        return (
+            isinstance(self.current_cover_tilt_position, int)
+            and (self.current_cover_tilt_position >= OPEN_POSITION-TILT_ONLY_OPENCLOSED_THRESHOLD
+                or self.current_cover_tilt_position <= CLOSED_POSITION+TILT_ONLY_OPENCLOSED_THRESHOLD
+            )
+        )

--- a/emu/PV_BLE_cover/PV_BLE_cover.ino
+++ b/emu/PV_BLE_cover/PV_BLE_cover.ino
@@ -2,6 +2,12 @@
  * Emulate a Hunter Douglas PowerView cover device using ESP32
  * used e.g. to gain the home_key from an existing installation via BLE
  * 
+ * REQUIRES:
+ * - ESP32 Board Definitions 3.0.x (tested on 3.0.7)
+ * - WolfSSL 5.7.x (tested on 5.7.6)
+ * - Phone Region: Potentially an alternative region depending on the app response
+ *  - e.g. To add Parkland shades in the US, phone region set to the UK temporarily
+ * 
  * TODO:
  * - cleanup code
  * - think about emulating a remote


### PR DESCRIPTION
Adding _very_ rudimentary support for the [Hunter Douglas Parkland](https://www.hunterdouglas.com/window-treatments/blinds/wood-blinds/parkland) blinds (tilt-only).
I was able to add all my blinds and have created automations for them that worked! 🎉 

0%-ish - Closed; mine only seem to close to ~3%
50% - Open
100%-ish - Closed

<img width="574" alt="image" src="https://github.com/user-attachments/assets/b2186e23-2fa8-4ec0-9b4b-ec8059bd4d0f" />

Feel free to edit/hack/throwaway. I'm super happy you made this project and that I don't need another silly gateway that'll cost hundreds of dollars.