### PR TITLE
feat: hub-based architecture for automatic shade discovery

### DIFF
--- a/custom_components/hunterdouglas_powerview_ble/__init__.py
+++ b/custom_components/hunterdouglas_powerview_ble/__init__.py
@@ -200,8 +200,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntryType) -> boo
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        for coordinator in entry.runtime_data.values():
-            coordinator._async_stop()  # noqa: SLF001
         entry.runtime_data.clear()
 
     LOGGER.debug("Unloaded config entry: %s, ok? %s!", entry.unique_id, str(unload_ok))

--- a/custom_components/hunterdouglas_powerview_ble/__init__.py
+++ b/custom_components/hunterdouglas_powerview_ble/__init__.py
@@ -42,7 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntryType) -> bool
             f"Could not find PowerView device ({entry.unique_id}) via Bluetooth"
         )
 
-    coordinator = PVCoordinator(hass, ble_device, entry.data.copy())
+    coordinator = PVCoordinator(hass, ble_device, entry.data.copy(), entry.title)
     try:
         await coordinator.query_dev_info()
     except BleakError as err:

--- a/custom_components/hunterdouglas_powerview_ble/__init__.py
+++ b/custom_components/hunterdouglas_powerview_ble/__init__.py
@@ -4,16 +4,33 @@
 @license: Apache-2.0 license
 """
 
+import base64
+from collections.abc import Callable
+
+import aiohttp
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
-from homeassistant.components.bluetooth import async_ble_device_from_address
+from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import (
+    BluetoothCallbackMatcher,
+    BluetoothScanningMode,
+    BluetoothServiceInfoBleak,
+    async_ble_device_from_address,
+    async_discovered_service_info,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import LOGGER
+from .api import UUID_COV_SERVICE as UUID
+from .const import CONF_HUB_URL, LOGGER, MFCT_ID, SIGNAL_NEW_SHADE
 from .coordinator import PVCoordinator
 
 PLATFORMS: list[Platform] = [
@@ -24,34 +41,157 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
 ]
 
-type ConfigEntryType = ConfigEntry[PVCoordinator]
+type HubRuntimeData = dict[str, PVCoordinator]
+type ConfigEntryType = ConfigEntry[HubRuntimeData]
+
+type AddEntitiesFn = Callable[[PVCoordinator, AddEntitiesCallback], None]
+
+
+def async_setup_shade_platform(
+    hass: HomeAssistant,
+    config_entry: ConfigEntryType,
+    async_add_entities: AddEntitiesCallback,
+    add_fn: AddEntitiesFn,
+) -> None:
+    """Set up a platform for all current and future shades."""
+    for coordinator in config_entry.runtime_data.values():
+        add_fn(coordinator, async_add_entities)
+
+    @callback
+    def _async_new_shade(coordinator: PVCoordinator) -> None:
+        add_fn(coordinator, async_add_entities)
+
+    config_entry.async_on_unload(
+        async_dispatcher_connect(
+            hass,
+            SIGNAL_NEW_SHADE.format(entry_id=config_entry.entry_id),
+            _async_new_shade,
+        )
+    )
+
+
+async def _fetch_shade_names(
+    hass: HomeAssistant, hub_url: str
+) -> dict[str, str]:
+    """Fetch BLE name -> friendly name mapping from the hub.
+
+    Returns empty dict on failure.
+    """
+    session = async_get_clientsession(hass)
+    timeout = aiohttp.ClientTimeout(total=10)
+    try:
+        async with session.get(f"{hub_url}/home/shades", timeout=timeout) as resp:
+            resp.raise_for_status()
+            shades = await resp.json(content_type=None)
+    except (TimeoutError, aiohttp.ClientError, ValueError):
+        return {}
+
+    names: dict[str, str] = {}
+    for shade in shades or []:
+        ble_name = shade.get("bleName", "")
+        if not ble_name:
+            continue
+        name_b64 = shade.get("name", "")
+        try:
+            name = base64.b64decode(name_b64).decode("utf-8") if name_b64 else ble_name
+        except Exception:  # noqa: BLE001
+            name = ble_name
+        names[ble_name] = name
+    return names
+
+
+async def _async_setup_shade(
+    hass: HomeAssistant,
+    entry: ConfigEntryType,
+    service_info: BluetoothServiceInfoBleak,
+    shade_names: dict[str, str],
+) -> None:
+    """Create a coordinator for a newly discovered shade."""
+    address = service_info.address
+
+    if address in entry.runtime_data:
+        return
+
+    ble_device: BLEDevice | None = async_ble_device_from_address(
+        hass=hass, address=address, connectable=True
+    )
+    if not ble_device:
+        LOGGER.debug("BLE device %s not connectable, skipping", address)
+        return
+
+    friendly_name = shade_names.get(service_info.name, service_info.name)
+
+    coordinator = PVCoordinator(
+        hass, ble_device, entry.data.copy(), friendly_name
+    )
+
+    entry.runtime_data[address] = coordinator
+    entry.async_on_unload(coordinator.async_start())
+
+    async_dispatcher_send(
+        hass,
+        SIGNAL_NEW_SHADE.format(entry_id=entry.entry_id),
+        coordinator,
+    )
+
+    # Query device info in background — don't block entry setup
+    try:
+        await coordinator.query_dev_info()
+    except BleakError:
+        LOGGER.warning(
+            "Could not query device info for %s (%s)",
+            friendly_name,
+            address,
+        )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntryType) -> bool:
-    """Set up BT Battery Management System from a config entry."""
+    """Set up PowerView Home from a config entry."""
     LOGGER.debug("Setup of %s", repr(entry))
 
-    if entry.unique_id is None:
-        raise ConfigEntryError("Missing unique ID for device.")
+    entry.runtime_data = {}
 
-    ble_device: BLEDevice | None = async_ble_device_from_address(
-        hass=hass, address=entry.unique_id, connectable=True
+    # Resolve shade friendly names from hub if available
+    hub_url = entry.data.get(CONF_HUB_URL, "")
+    shade_names: dict[str, str] = {}
+    if hub_url:
+        shade_names = await _fetch_shade_names(hass, hub_url)
+
+    # Forward platforms first so dispatched entities have their setup ready
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Kick off shade setup for already-discovered BLE devices (non-blocking)
+    for service_info in async_discovered_service_info(hass, connectable=True):
+        if (
+            MFCT_ID in service_info.manufacturer_data
+            and UUID in service_info.service_uuids
+        ):
+            hass.async_create_task(
+                _async_setup_shade(hass, entry, service_info, shade_names)
+            )
+
+    # Register for future BLE discoveries
+    def _async_discovered_device(
+        service_info: BluetoothServiceInfoBleak,
+        change: bluetooth.BluetoothChange,
+    ) -> None:
+        if service_info.address not in entry.runtime_data:
+            hass.async_create_task(
+                _async_setup_shade(hass, entry, service_info, shade_names)
+            )
+
+    entry.async_on_unload(
+        bluetooth.async_register_callback(
+            hass,
+            _async_discovered_device,
+            BluetoothCallbackMatcher(
+                service_uuid=UUID,
+                manufacturer_id=MFCT_ID,
+            ),
+            BluetoothScanningMode.ACTIVE,
+        )
     )
 
-    if not ble_device:
-        raise ConfigEntryNotReady(
-            f"Could not find PowerView device ({entry.unique_id}) via Bluetooth"
-        )
-
-    coordinator = PVCoordinator(hass, ble_device, entry.data.copy(), entry.title)
-    try:
-        await coordinator.query_dev_info()
-    except BleakError as err:
-        raise ConfigEntryNotReady("Unable to query device info.") from err
-
-    entry.runtime_data = coordinator
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    entry.async_on_unload(coordinator.async_start())
     return True
 
 
@@ -59,20 +199,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntryType) -> boo
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
+    if unload_ok:
+        for coordinator in entry.runtime_data.values():
+            coordinator._async_stop()  # noqa: SLF001
+        entry.runtime_data.clear()
+
     LOGGER.debug("Unloaded config entry: %s, ok? %s!", entry.unique_id, str(unload_ok))
     return unload_ok
-
-
-async def async_migrate_entry(
-    _hass: HomeAssistant, config_entry: ConfigEntryType
-) -> bool:
-    """Migrate old entry."""
-
-    if config_entry.version > 1:
-        # This means the user has downgraded from a future version
-        LOGGER.debug("Cannot downgrade from version %s", config_entry.version)
-        return False
-
-    LOGGER.debug("Migrating from version %s", config_entry.version)
-
-    return False

--- a/custom_components/hunterdouglas_powerview_ble/__init__.py
+++ b/custom_components/hunterdouglas_powerview_ble/__init__.py
@@ -18,9 +18,10 @@ from .coordinator import PVCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
-    Platform.COVER,
-    Platform.SENSOR,
     Platform.BUTTON,
+    Platform.COVER,
+    Platform.NUMBER,
+    Platform.SENSOR,
 ]
 
 type ConfigEntryType = ConfigEntry[PVCoordinator]

--- a/custom_components/hunterdouglas_powerview_ble/__init__.py
+++ b/custom_components/hunterdouglas_powerview_ble/__init__.py
@@ -185,21 +185,23 @@ async def _async_setup_shade(
             entry, data={**entry.data, CONF_POWER_TYPES: cached_map}
         )
 
+    # Populate dev_details before entity dispatch so the device registers with
+    # firmware/serial on first creation — the HA registry doesn't re-read
+    # DeviceInfo later. Failures are retried from the advertisement handler.
+    try:
+        await coordinator.query_dev_info()
+    except (BleakError, TimeoutError):
+        LOGGER.debug(
+            "Initial device info query failed for %s (%s); will retry via adverts",
+            friendly_name,
+            address,
+        )
+
     async_dispatcher_send(
         hass,
         SIGNAL_NEW_SHADE.format(entry_id=entry.entry_id),
         coordinator,
     )
-
-    # Query device info in background — don't block entry setup
-    try:
-        await coordinator.query_dev_info()
-    except BleakError:
-        LOGGER.warning(
-            "Could not query device info for %s (%s)",
-            friendly_name,
-            address,
-        )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntryType) -> bool:

--- a/custom_components/hunterdouglas_powerview_ble/__init__.py
+++ b/custom_components/hunterdouglas_powerview_ble/__init__.py
@@ -4,8 +4,10 @@
 @license: Apache-2.0 license
 """
 
+import asyncio
 import base64
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import aiohttp
 from bleak.backends.device import BLEDevice
@@ -30,8 +32,32 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .api import UUID_COV_SERVICE as UUID
-from .const import CONF_HUB_URL, LOGGER, MFCT_ID, SIGNAL_NEW_SHADE
+from .const import (
+    CONF_HUB_URL,
+    CONF_POWER_TYPES,
+    LOGGER,
+    MFCT_ID,
+    SIGNAL_NEW_SHADE,
+    PowerType,
+)
 from .coordinator import PVCoordinator
+
+# Hub /home/shades powerType (aiopvapi Gen3: 1=hardwired, 2=battery,
+# 3=rechargeable) → our internal PowerType (matches BLE 0xFFDE byte 0).
+_HUB_POWERTYPE_TO_INTERNAL: dict[int, PowerType] = {
+    1: PowerType.HARDWIRED,
+    2: PowerType.BATTERY,
+    3: PowerType.RECHARGEABLE,
+}
+
+
+@dataclass(frozen=True)
+class ShadeMetadata:
+    """Per-shade metadata sourced from the G3 hub's /home/shades response."""
+
+    friendly_name: str
+    power_type: PowerType | None = None
+
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -70,10 +96,10 @@ def async_setup_shade_platform(
     )
 
 
-async def _fetch_shade_names(
+async def _fetch_shade_metadata(
     hass: HomeAssistant, hub_url: str
-) -> dict[str, str]:
-    """Fetch BLE name -> friendly name mapping from the hub.
+) -> dict[str, ShadeMetadata]:
+    """Fetch per-shade metadata (friendly name, power_type) from the hub.
 
     Returns empty dict on failure.
     """
@@ -86,7 +112,7 @@ async def _fetch_shade_names(
     except (TimeoutError, aiohttp.ClientError, ValueError):
         return {}
 
-    names: dict[str, str] = {}
+    metadata: dict[str, ShadeMetadata] = {}
     for shade in shades or []:
         ble_name = shade.get("bleName", "")
         if not ble_name:
@@ -96,15 +122,19 @@ async def _fetch_shade_names(
             name = base64.b64decode(name_b64).decode("utf-8") if name_b64 else ble_name
         except Exception:  # noqa: BLE001
             name = ble_name
-        names[ble_name] = name
-    return names
+        raw_pt = shade.get("powerType")
+        power_type = (
+            _HUB_POWERTYPE_TO_INTERNAL.get(raw_pt) if isinstance(raw_pt, int) else None
+        )
+        metadata[ble_name] = ShadeMetadata(friendly_name=name, power_type=power_type)
+    return metadata
 
 
 async def _async_setup_shade(
     hass: HomeAssistant,
     entry: ConfigEntryType,
     service_info: BluetoothServiceInfoBleak,
-    shade_names: dict[str, str],
+    shade_metadata: dict[str, ShadeMetadata],
 ) -> None:
     """Create a coordinator for a newly discovered shade."""
     address = service_info.address
@@ -119,14 +149,41 @@ async def _async_setup_shade(
         LOGGER.debug("BLE device %s not connectable, skipping", address)
         return
 
-    friendly_name = shade_names.get(service_info.name, service_info.name)
+    meta = shade_metadata.get(service_info.name)
+    friendly_name = meta.friendly_name if meta else service_info.name
+    cached_map: dict[str, int] = dict(entry.data.get(CONF_POWER_TYPES, {}))
+    power_type: PowerType | None = meta.power_type if meta else None
+    if power_type is None:
+        cached_value = cached_map.get(address)
+        if isinstance(cached_value, int):
+            try:
+                power_type = PowerType(cached_value)
+            except ValueError:
+                power_type = None
 
     coordinator = PVCoordinator(
-        hass, ble_device, entry.data.copy(), friendly_name
+        hass, ble_device, entry.data.copy(), friendly_name, power_type
     )
 
     entry.runtime_data[address] = coordinator
     entry.async_on_unload(coordinator.async_start())
+
+    # BLE fallback for hub-less (manual-key) setups: one-time query so the
+    # entity platforms (dispatched below) see the resolved value.
+    if coordinator.power_type is None and coordinator.api.has_key:
+        try:
+            await asyncio.wait_for(coordinator.query_power_type(), timeout=10)
+        except (BleakError, TimeoutError):
+            LOGGER.debug("power_type BLE fallback failed for %s", address)
+
+    # Persist any newly-resolved power_type so hub-down restarts keep classification.
+    if coordinator.power_type is not None and cached_map.get(address) != int(
+        coordinator.power_type
+    ):
+        cached_map[address] = int(coordinator.power_type)
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_POWER_TYPES: cached_map}
+        )
 
     async_dispatcher_send(
         hass,
@@ -151,11 +208,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntryType) -> bool
 
     entry.runtime_data = {}
 
-    # Resolve shade friendly names from hub if available
+    # Resolve shade friendly names and power_type from hub if available
     hub_url = entry.data.get(CONF_HUB_URL, "")
-    shade_names: dict[str, str] = {}
+    shade_metadata: dict[str, ShadeMetadata] = {}
     if hub_url:
-        shade_names = await _fetch_shade_names(hass, hub_url)
+        shade_metadata = await _fetch_shade_metadata(hass, hub_url)
 
     # Forward platforms first so dispatched entities have their setup ready
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -167,7 +224,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntryType) -> bool
             and UUID in service_info.service_uuids
         ):
             hass.async_create_task(
-                _async_setup_shade(hass, entry, service_info, shade_names)
+                _async_setup_shade(hass, entry, service_info, shade_metadata)
             )
 
     # Register for future BLE discoveries
@@ -177,7 +234,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntryType) -> bool
     ) -> None:
         if service_info.address not in entry.runtime_data:
             hass.async_create_task(
-                _async_setup_shade(hass, entry, service_info, shade_names)
+                _async_setup_shade(hass, entry, service_info, shade_metadata)
             )
 
     entry.async_on_unload(

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -40,23 +40,38 @@ SHADE_TYPE: Final[dict[int, str]] = {
     6: "Duette",
     10: "Duette and Applause SkyLift",
     19: "Provenance Woven Wood",
+    26: "Vertical",
     31: "Vignette",
     32: "Vignette",
     42: "M25T Roller Blind",
     49: "AC Roller",
     52: "Banded Shades",
     53: "Sonnette",
+    57: "Carole Roman Shades",
     84: "Vignette",
-    # top down bottom up
+    # top down (single rail, inverted position)
+    7: "Top Down",
+    # top down bottom up (dual rail)
     8: "Duette, Top Down Bottom Up",
     9: "Duette DuoLite, Top Down Bottom Up",
     33: "Duette Architella, Top Down Bottom Up",
-    39: "Parkland",
     47: "Pleated, Top Down Bottom Up",
+    # tilt only (no position movement)
+    39: "Parkland",
+    40: "Everwood Alternative Wood Blinds",
+    # tilt on closed
+    18: "Bottom Up, Tilt on Closed 90°",
+    44: "Twist",
     # tilt anywhere (position + tilt)
     51: "Venetian, Tilt Anywhere",
-    54: "Vertical Blind, Tilt",
+    54: "Vertical Slats, Left Stack",
+    55: "Vertical Slats, Right Stack",
+    56: "Vertical Slats, Split Stack",
     62: "Venetian, Tilt Anywhere",
+    # duolite (dual overlapping fabrics)
+    38: "Dual Overlapped, Tilt 90°",
+    65: "Dual Overlapped",
+    95: "Dual Overlapped Illuminated",
 }
 
 class ShadeCapability(NamedTuple):
@@ -73,17 +88,27 @@ SHADE_CAPABILITIES: Final[dict[int, ShadeCapability]] = {
     # tilt anywhere (position + tilt)
     51: ShadeCapability(has_tilt=True),
     54: ShadeCapability(has_tilt=True),
+    55: ShadeCapability(has_tilt=True),
+    56: ShadeCapability(has_tilt=True),
     62: ShadeCapability(has_tilt=True),
     # tilt only (no position movement)
     39: ShadeCapability(has_tilt=True, tilt_only=True),
-    # top-down only (inverted position: 100 = fully raised, 0 = fully lowered)
+    40: ShadeCapability(has_tilt=True, tilt_only=True),
+    # tilt on closed (tilt only available at fully closed position)
+    18: ShadeCapability(has_tilt=True),
+    44: ShadeCapability(has_tilt=True),
+    # top-down only (single rail, inverted position)
+    7: ShadeCapability(is_top_down=True),
     10: ShadeCapability(is_top_down=True),
     # dual-rail top-down/bottom-up (two independent rails → two entities)
     8: ShadeCapability(is_tdbu=True),
     33: ShadeCapability(is_tdbu=True),
     47: ShadeCapability(is_tdbu=True),
-    # duolite top-down/bottom-up (sheer front + opaque rear → three entities)
+    # duolite (dual overlapping fabrics → three entities)
     9: ShadeCapability(is_tdbu=True, is_duolite=True),
+    38: ShadeCapability(is_duolite=True),
+    65: ShadeCapability(is_duolite=True),
+    95: ShadeCapability(is_duolite=True),
 }
 
 _DEFAULT_CAPABILITY: Final[ShadeCapability] = ShadeCapability()

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -79,6 +79,7 @@ class ShadeCapability(NamedTuple):
 
     has_tilt: bool = False
     tilt_only: bool = False
+    is_tilt_on_closed: bool = False  # tilt only available when fully closed
     is_top_down: bool = False  # position logic is inverted (SkyLift style)
     is_tdbu: bool = False  # dual-rail Top Down Bottom Up (needs two entities)
     is_duolite: bool = False  # dual-fabric sheer+opaque (needs three entities)
@@ -95,8 +96,8 @@ SHADE_CAPABILITIES: Final[dict[int, ShadeCapability]] = {
     39: ShadeCapability(has_tilt=True, tilt_only=True),
     40: ShadeCapability(has_tilt=True, tilt_only=True),
     # tilt on closed (tilt only available at fully closed position)
-    18: ShadeCapability(has_tilt=True),
-    44: ShadeCapability(has_tilt=True),
+    18: ShadeCapability(has_tilt=True, is_tilt_on_closed=True),
+    44: ShadeCapability(has_tilt=True, is_tilt_on_closed=True),
     # top-down only (single rail, inverted position)
     7: ShadeCapability(is_top_down=True),
     10: ShadeCapability(is_top_down=True),

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -63,6 +63,9 @@ class ShadeCapability(NamedTuple):
 
     has_tilt: bool = False
     tilt_only: bool = False
+    is_top_down: bool = False  # position logic is inverted (SkyLift style)
+    is_tdbu: bool = False  # dual-rail Top Down Bottom Up (needs two entities)
+    is_duolite: bool = False  # dual-fabric sheer+opaque (needs three entities)
 
 
 SHADE_CAPABILITIES: Final[dict[int, ShadeCapability]] = {
@@ -71,6 +74,14 @@ SHADE_CAPABILITIES: Final[dict[int, ShadeCapability]] = {
     62: ShadeCapability(has_tilt=True),
     # tilt only (no position movement)
     39: ShadeCapability(has_tilt=True, tilt_only=True),
+    # top-down only (inverted position: 100 = fully raised, 0 = fully lowered)
+    10: ShadeCapability(is_top_down=True),
+    # dual-rail top-down/bottom-up (two independent rails → two entities)
+    8: ShadeCapability(is_tdbu=True),
+    33: ShadeCapability(is_tdbu=True),
+    47: ShadeCapability(is_tdbu=True),
+    # duolite top-down/bottom-up (sheer front + opaque rear → three entities)
+    9: ShadeCapability(is_tdbu=True, is_duolite=True),
 }
 
 _DEFAULT_CAPABILITY: Final[ShadeCapability] = ShadeCapability()

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -53,8 +53,9 @@ SHADE_TYPE: Final[dict[int, str]] = {
     33: "Duette Architella, Top Down Bottom Up",
     39: "Parkland",
     47: "Pleated, Top Down Bottom Up",
-    # top down, tilt anywhere
+    # tilt anywhere (position + tilt)
     51: "Venetian, Tilt Anywhere",
+    54: "Vertical Blind, Tilt",
     62: "Venetian, Tilt Anywhere",
 }
 
@@ -71,6 +72,7 @@ class ShadeCapability(NamedTuple):
 SHADE_CAPABILITIES: Final[dict[int, ShadeCapability]] = {
     # tilt anywhere (position + tilt)
     51: ShadeCapability(has_tilt=True),
+    54: ShadeCapability(has_tilt=True),
     62: ShadeCapability(has_tilt=True),
     # tilt only (no position movement)
     39: ShadeCapability(has_tilt=True, tilt_only=True),

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -97,18 +97,10 @@ class PowerViewBLE:
 
     def __init__(self, ble_device: BLEDevice, home_key: bytes = b"") -> None:
         """Initialize device API via Bluetooth."""
-        self._ble_device: Final[BLEDevice] = ble_device
+        self._ble_device: BLEDevice = ble_device
         self.name: Final[str] = self._ble_device.name or "unknown"
         self._seqcnt: int = 1
-        self._client: BleakClient = BleakClient(
-            self._ble_device,
-            disconnected_callback=self._on_disconnect,
-            services=[
-                UUID_COV_SERVICE,
-                UUID_DEV_SERVICE,
-                # self.UUID_BAT_SERVICE,
-            ],
-        )
+        self._client: BleakClient = BleakClient(self._ble_device)
         self._data_event = asyncio.Event()
         self._data: bytes = b""
         self._info: PVDeviceInfo = PVDeviceInfo()
@@ -124,6 +116,10 @@ class PowerViewBLE:
     async def _wait_event(self) -> None:
         await self._data_event.wait()
         self._data_event.clear()
+
+    def set_ble_device(self, ble_device: BLEDevice) -> None:
+        """Update the BLE device reference (e.g. when proxy details change)."""
+        self._ble_device = ble_device
 
     @property
     def encrypted(self) -> bool:
@@ -360,6 +356,7 @@ class PowerViewBLE:
             self._ble_device,
             self.name,
             disconnected_callback=self._on_disconnect,
+            ble_device_callback=lambda: self._ble_device,
             services=[
                 UUID_COV_SERVICE,
                 UUID_DEV_SERVICE,

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -226,18 +226,25 @@ class PowerViewBLE:
         if len(data) != 9:
             LOGGER.debug("not a V2 record!")
             return {}
-        pos: Final[int] = int.from_bytes(data[3:5], byteorder="little")
+        # data[3] lower 2 bits are status flags; pos is in bits 2-7 of data[3]
+        # and bits 0-3 of data[4].  Read flags before extracting position so
+        # the masking below doesn't accidentally overwrite them.
+        flags: Final[int] = data[3] & 0x3
+        # Mask pos2 bits (upper nibble of data[4]) out before forming the
+        # 10-bit position value, otherwise a non-zero top-rail position on
+        # TDBU shades contaminates the bottom-rail reading.
+        pos: Final[int] = ((data[4] & 0x0F) << 6) | ((data[3] >> 2) & 0x3F)
         pos2: Final[int] = (int(data[5]) << 4) + (int(data[4]) >> 4)
         return {
-            ATTR_CURRENT_POSITION: (pos >> 2) / 10,
+            ATTR_CURRENT_POSITION: pos / 10,
             "position2": pos2 >> 2,
             "position3": int(data[6]),
             ATTR_CURRENT_TILT_POSITION: int(data[7]),
             "home_id": int.from_bytes(data[0:2], byteorder="little"),
             "type_id": int(data[2]),
-            "is_opening": bool(pos & 0x3 == 0x2),
-            "is_closing": bool(pos & 0x3 == 0x1),
-            "battery_charging": bool(pos & 0x3 == 0x3),  # observed
+            "is_opening": bool(flags == 0x2),
+            "is_closing": bool(flags == 0x1),
+            "battery_charging": bool(flags == 0x3),  # observed
             "battery_level": POWER_LEVELS[(data[8] >> 6)],  # cannot hit 4
             "resetMode": bool(data[8] & 0x1),
             "resetClock": bool(data[8] & 0x2),

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -219,27 +219,27 @@ class PowerViewBLE:
                 raise
 
     @staticmethod
-    def dec_manufacturer_data(data: bytearray) -> list[tuple[str, float]]:
+    def dec_manufacturer_data(data: bytearray) -> dict[str, float | int | bool]:
         """Decode manufacturer data from BLE advertisement V2."""
         if len(data) != 9:
             LOGGER.debug("not a V2 record!")
-            return []
+            return {}
         pos: Final[int] = int.from_bytes(data[3:5], byteorder="little")
         pos2: Final[int] = (int(data[5]) << 4) + (int(data[4]) >> 4)
-        return [
-            (ATTR_CURRENT_POSITION, ((pos >> 2) / 10)),
-            ("position2", pos2 >> 2),
-            ("position3", int(data[6])),
-            (ATTR_CURRENT_TILT_POSITION, int(data[7])),
-            ("home_id", int.from_bytes(data[0:2], byteorder="little")),
-            ("type_id", int(data[2])),
-            ("is_opening", bool(pos & 0x3 == 0x2)),
-            ("is_closing", bool(pos & 0x3 == 0x1)),
-            ("battery_charging", bool(pos & 0x3 == 0x3)),  # observed
-            ("battery_level", POWER_LEVELS[(data[8] >> 6)]),  # cannot hit 4
-            ("resetMode", bool(data[8] & 0x1)),
-            ("resetClock", bool(data[8] & 0x2)),
-        ]
+        return {
+            ATTR_CURRENT_POSITION: (pos >> 2) / 10,
+            "position2": pos2 >> 2,
+            "position3": int(data[6]),
+            ATTR_CURRENT_TILT_POSITION: int(data[7]),
+            "home_id": int.from_bytes(data[0:2], byteorder="little"),
+            "type_id": int(data[2]),
+            "is_opening": bool(pos & 0x3 == 0x2),
+            "is_closing": bool(pos & 0x3 == 0x1),
+            "battery_charging": bool(pos & 0x3 == 0x3),  # observed
+            "battery_level": POWER_LEVELS[(data[8] >> 6)],  # cannot hit 4
+            "resetMode": bool(data[8] & 0x1),
+            "resetClock": bool(data[8] & 0x2),
+        }
 
     # position cmd: uint16_t pos1, uint16_t pos2, uint16_t pos3, uint16_t tilt, uint8_t velocity
     async def set_position(

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -228,7 +228,7 @@ class PowerViewBLE:
         await self._cmd(
             (
                 ShadeCmd.SET_POSITION,
-                int.to_bytes(pos1*100, 2, byteorder="little")
+                int.to_bytes(pos1 * 100, 2, byteorder="little")
                 + int.to_bytes(pos2, 2, byteorder="little")
                 + int.to_bytes(pos3, 2, byteorder="little")
                 + int.to_bytes(tilt, 2, byteorder="little")

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -135,6 +135,11 @@ class PowerViewBLE:
         self._is_encrypted = value
 
     @property
+    def has_key(self) -> bool:
+        """Return True if a valid homekey was provided."""
+        return self._cipher is not None
+
+    @property
     def info(self) -> PVDeviceInfo:
         """Return device information, e.g. SW version."""
         return self._info

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -4,7 +4,7 @@ import asyncio
 from dataclasses import dataclass
 from enum import Enum
 import time
-from typing import Final
+from typing import Final, NamedTuple
 
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
@@ -57,6 +57,31 @@ SHADE_TYPE: Final[dict[int, str]] = {
     51: "Venetian, Tilt Anywhere",
     62: "Venetian, Tilt Anywhere",
 }
+
+class ShadeCapability(NamedTuple):
+    """Capability flags for a shade type."""
+
+    has_tilt: bool = False
+    tilt_only: bool = False
+
+
+SHADE_CAPABILITIES: Final[dict[int, ShadeCapability]] = {
+    # tilt anywhere (position + tilt)
+    51: ShadeCapability(has_tilt=True),
+    62: ShadeCapability(has_tilt=True),
+    # tilt only (no position movement)
+    39: ShadeCapability(has_tilt=True, tilt_only=True),
+}
+
+_DEFAULT_CAPABILITY: Final[ShadeCapability] = ShadeCapability()
+
+
+def get_shade_capabilities(type_id: int | None) -> ShadeCapability:
+    """Return shade capabilities for a given type_id."""
+    if type_id is None:
+        return _DEFAULT_CAPABILITY
+    return SHADE_CAPABILITIES.get(type_id, _DEFAULT_CAPABILITY)
+
 
 OPEN_POSITION: Final[int] = 100
 CLOSED_POSITION: Final[int] = 0
@@ -237,20 +262,20 @@ class PowerViewBLE:
             disconnect,
         )
 
-    async def open(self) -> None:
+    async def open(self, velocity: int = 0x0) -> None:
         """Fully open cover."""
         LOGGER.debug("%s open", self.name)
-        await self.set_position(OPEN_POSITION, disconnect=False)
+        await self.set_position(OPEN_POSITION, velocity=velocity, disconnect=False)
 
     async def stop(self) -> None:
         """Stop device movement."""
         LOGGER.debug("%s stop", self.name)
         await self._cmd((ShadeCmd.STOP, b""))
 
-    async def close(self) -> None:
+    async def close(self, velocity: int = 0x0) -> None:
         """Fully close cover."""
         LOGGER.debug("%s close", self.name)
-        await self.set_position(CLOSED_POSITION, disconnect=False)
+        await self.set_position(CLOSED_POSITION, velocity=velocity, disconnect=False)
 
     # uint8_t scene#, uint8_t unknown
     # open: scene 2

--- a/custom_components/hunterdouglas_powerview_ble/api.py
+++ b/custom_components/hunterdouglas_powerview_ble/api.py
@@ -22,7 +22,7 @@ from homeassistant.components.cover import (
     ATTR_CURRENT_TILT_POSITION,
 )
 
-from .const import LOGGER, TIMEOUT
+from .const import LOGGER, TIMEOUT, PowerType
 
 UUID_COV_SERVICE: Final[str] = normalize_uuid_str("fdc1")
 UUID_TX: Final[str] = "cafe1001-c0ff-ee01-8000-a110ca7ab1e0"
@@ -73,6 +73,7 @@ SHADE_TYPE: Final[dict[int, str]] = {
     65: "Dual Overlapped",
     95: "Dual Overlapped Illuminated",
 }
+
 
 class ShadeCapability(NamedTuple):
     """Capability flags for a shade type."""
@@ -126,8 +127,7 @@ OPEN_POSITION: Final[int] = 100
 CLOSED_POSITION: Final[int] = 0
 
 POWER_LEVELS: Final[dict[int, int]] = {
-    4: 100,  # 4 is hardwired
-    3: 100,  # 3 = 100% to 51% power remaining
+    3: 100,  # 3 = 100% to 51% power remaining (also reported by hardwired)
     2: 50,  # 2 = 50% to 21% power remaining
     1: 20,  # 1 = 20% or less power remaining
     0: 0,  # 0 = No power remaining
@@ -141,6 +141,7 @@ class ShadeCmd(Enum):
     STOP = 0xB8F7
     ACTIVATE_SCENE = 0xBAF7
     IDENTIFY = 0x11F7
+    POWER_STATUS = 0xDEFF
 
 
 @dataclass
@@ -209,6 +210,28 @@ class PowerViewBLE:
         """Return whether remote device is connected."""
         return self._client.is_connected
 
+    async def _transact(self, cmd: tuple[ShadeCmd, bytes]) -> int:
+        # Assumes _cmd_lock is held and _connect() has run. Writes a framed
+        # (optionally encrypted) request and waits for the device's reply;
+        # caller inspects/validates self._data afterwards. Returns the seq
+        # number used so callers can verify the echo.
+        tx_data: bytes = bytes(
+            int.to_bytes(cmd[0].value, 2, byteorder="little")
+            + bytes([self._seqcnt, len(cmd[1])])
+            + cmd[1]
+        )
+        LOGGER.debug("sending cmd: %s", tx_data.hex(" "))
+        if self._cipher is not None and self._is_encrypted:
+            enc: AEADEncryptionContext = self._cipher.encryptor()
+            tx_data = enc.update(tx_data) + enc.finalize()
+            LOGGER.debug("  encrypted: %s", tx_data.hex(" "))
+        self._data_event.clear()
+        await self._client.write_gatt_char(UUID_TX, tx_data, False)
+        seq = self._seqcnt
+        self._seqcnt += 1
+        await asyncio.wait_for(self._wait_event(), timeout=TIMEOUT)
+        return seq
+
     # general cmd: uint16_t cmd, uint8_t seqID, uint8_t data_len
     async def _cmd(self, cmd: tuple[ShadeCmd, bytes], disconnect: bool = True) -> None:
         self._cmd_next = cmd
@@ -220,23 +243,9 @@ class PowerViewBLE:
             try:
                 await self._connect()
                 cmd_run: tuple[ShadeCmd, bytes] = self._cmd_next
-                tx_data: bytes = bytes(
-                    int.to_bytes(cmd_run[0].value, 2, byteorder="little")
-                    + bytes([self._seqcnt, len(cmd_run[1])])
-                    + cmd_run[1]
-                )
-                LOGGER.debug("sending cmd: %s", tx_data.hex(" "))
-                if self._cipher is not None and self._is_encrypted:
-                    enc: AEADEncryptionContext = self._cipher.encryptor()
-                    tx_data = enc.update(tx_data) + enc.finalize()
-                    LOGGER.debug("  encrypted: %s", tx_data.hex(" "))
-                self._data_event.clear()
-                await self._client.write_gatt_char(UUID_TX, tx_data, False)
-                self._seqcnt += 1
-                LOGGER.debug("waiting for response")
                 try:
-                    await asyncio.wait_for(self._wait_event(), timeout=TIMEOUT)
-                    self._verify_response(self._data, self._seqcnt - 1, cmd_run[0])
+                    seq = await self._transact(cmd_run)
+                    self._verify_ack_reply(self._data, seq, cmd_run[0])
                 except TimeoutError as ex:
                     raise TimeoutError("Device did not send confirmation.") from ex
                 finally:
@@ -245,6 +254,22 @@ class PowerViewBLE:
             except Exception as ex:
                 LOGGER.error("Error: %s - %s", type(ex).__name__, ex)
                 raise
+
+    async def _query(self, cmd: tuple[ShadeCmd, bytes]) -> bytes:
+        """Send a read-type opcode and return its payload bytes."""
+        async with self._cmd_lock:
+            await self._connect()
+            try:
+                try:
+                    seq = await self._transact(cmd)
+                except TimeoutError as ex:
+                    raise TimeoutError("Device did not send response.") from ex
+                if not self._verify_header(self._data, seq, cmd[0]):
+                    raise BleakError("Malformed query response header")
+                length = int(self._data[3])
+                return bytes(self._data[4 : 4 + length])
+            finally:
+                await self._client.disconnect()
 
     @staticmethod
     def dec_manufacturer_data(data: bytearray) -> dict[str, float | int | bool]:
@@ -271,7 +296,7 @@ class PowerViewBLE:
             "is_opening": bool(flags == 0x2),
             "is_closing": bool(flags == 0x1),
             "battery_charging": bool(flags == 0x3),  # observed
-            "battery_level": POWER_LEVELS[(data[8] >> 6)],  # cannot hit 4
+            "battery_level": POWER_LEVELS[(data[8] >> 6)],
             "resetMode": bool(data[8] & 0x1),
             "resetClock": bool(data[8] & 0x2),
         }
@@ -341,8 +366,8 @@ class PowerViewBLE:
         LOGGER.debug("%s identify (%i)", self.name, beeps)
         await self._cmd((ShadeCmd.IDENTIFY, bytes([min(beeps, 0xFF)])))
 
-    def _verify_response(self, data: bytes, seq_nr: int, cmd: ShadeCmd) -> bool:
-        """Verify shade response data."""
+    def _verify_header(self, data: bytes, seq_nr: int, cmd: ShadeCmd) -> bool:
+        """Verify common header fields (length, echoed opcode, seq match)."""
         if len(data) < 4:
             LOGGER.error("Response message too short")
             return False
@@ -353,6 +378,12 @@ class PowerViewBLE:
             LOGGER.warning(
                 "Response sequence id %i wrong, expected %d", int(data[2]), seq_nr
             )
+            return False
+        return True
+
+    def _verify_ack_reply(self, data: bytes, seq_nr: int, cmd: ShadeCmd) -> bool:
+        """Verify an ack-only reply (1-byte status payload, 0 == success)."""
+        if not self._verify_header(data, seq_nr, cmd):
             return False
         if int(data[3]) != 1:
             LOGGER.error("Wrong response data length")
@@ -392,6 +423,37 @@ class PowerViewBLE:
                 await self.disconnect()
         LOGGER.debug("%s device data: %s", self.name, data)
         return data.copy()
+
+    async def query_power_type(self) -> PowerType | None:
+        """Return the shade's power source, or None if unknown/unavailable."""
+        if self._cipher is None:
+            return None
+        try:
+            payload = await self._query((ShadeCmd.POWER_STATUS, b""))
+        except (BleakError, TimeoutError) as ex:
+            LOGGER.debug("%s: power_type query failed: %s", self.name, ex)
+            return None
+
+        # A 1-byte reply is an error code (e.g. 0x04 = invalid length); it
+        # must NOT be returned as a power_type or it would be misread as
+        # PowerType.value=4.
+        if len(payload) == 1:
+            LOGGER.debug(
+                "%s: power_type query rejected (err=0x%02X)", self.name, payload[0]
+            )
+            return None
+        if len(payload) == 8:
+            try:
+                return PowerType(payload[0])
+            except ValueError:
+                LOGGER.debug(
+                    "%s: unknown power_type byte 0x%02X", self.name, payload[0]
+                )
+                return None
+        LOGGER.debug(
+            "%s: unexpected power_type payload length %d", self.name, len(payload)
+        )
+        return None
 
     def _on_disconnect(self, client: BleakClient) -> None:
         """Disconnect callback function."""

--- a/custom_components/hunterdouglas_powerview_ble/binary_sensor.py
+++ b/custom_components/hunterdouglas_powerview_ble/binary_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ConfigEntryType
+from . import ConfigEntryType, async_setup_shade_platform
 from .const import DOMAIN
 from .coordinator import PVCoordinator
 
@@ -26,18 +26,25 @@ BINARY_SENSOR_TYPES: list[BinarySensorEntityDescription] = [
 ]
 
 
+def _add_entities(
+    coordinator: PVCoordinator, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Create binary sensor entities for a single shade coordinator."""
+    async_add_entities(
+        [
+            PVBinarySensor(coordinator, descr, format_mac(coordinator.address))
+            for descr in BINARY_SENSOR_TYPES
+        ]
+    )
+
+
 async def async_setup_entry(
-    _hass: HomeAssistant,
+    hass: HomeAssistant,
     config_entry: ConfigEntryType,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add sensors for passed config_entry in Home Assistant."""
-
-    coord: PVCoordinator = config_entry.runtime_data
-    for descr in BINARY_SENSOR_TYPES:
-        async_add_entities(
-            [PVBinarySensor(coord, descr, format_mac(config_entry.unique_id))]
-        )
+    async_setup_shade_platform(hass, config_entry, async_add_entities, _add_entities)
 
 
 class PVBinarySensor(

--- a/custom_components/hunterdouglas_powerview_ble/binary_sensor.py
+++ b/custom_components/hunterdouglas_powerview_ble/binary_sensor.py
@@ -40,7 +40,9 @@ async def async_setup_entry(
         )
 
 
-class PVBinarySensor(PassiveBluetoothCoordinatorEntity[PVCoordinator], BinarySensorEntity):  # type: ignore[reportIncompatibleMethodOverride]
+class PVBinarySensor(
+    PassiveBluetoothCoordinatorEntity[PVCoordinator], BinarySensorEntity
+):  # type: ignore[reportIncompatibleMethodOverride]
     """The generic PV binary sensor implementation."""
 
     def __init__(

--- a/custom_components/hunterdouglas_powerview_ble/binary_sensor.py
+++ b/custom_components/hunterdouglas_powerview_ble/binary_sensor.py
@@ -30,10 +30,12 @@ def _add_entities(
     coordinator: PVCoordinator, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Create binary sensor entities for a single shade coordinator."""
+    include_battery = coordinator.show_battery_entities
     async_add_entities(
         [
             PVBinarySensor(coordinator, descr, format_mac(coordinator.address))
             for descr in BINARY_SENSOR_TYPES
+            if include_battery or descr.key != ATTR_BATTERY_CHARGING
         ]
     )
 

--- a/custom_components/hunterdouglas_powerview_ble/button.py
+++ b/custom_components/hunterdouglas_powerview_ble/button.py
@@ -12,7 +12,7 @@ from homeassistant.components.button import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo, format_mac
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ConfigEntryType, async_setup_shade_platform
@@ -50,7 +50,6 @@ class PowerViewButton(PassiveBluetoothCoordinatorEntity[PVCoordinator], ButtonEn
     """Representation of a powerview shade."""
 
     _attr_has_entity_name = True
-    _attr_device_class = ButtonDeviceClass.IDENTIFY
 
     def __init__(
         self,
@@ -65,11 +64,6 @@ class PowerViewButton(PassiveBluetoothCoordinatorEntity[PVCoordinator], ButtonEn
             f"{DOMAIN}_{format_mac(self._coord.address)}_{ButtonDeviceClass.IDENTIFY}"
         )
         super().__init__(coordinator)
-
-    @property
-    def device_info(self) -> DeviceInfo:  # type: ignore[reportIncompatibleVariableOverride]
-        """Return the device_info of the device."""
-        return self._coord.device_info
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/custom_components/hunterdouglas_powerview_ble/button.py
+++ b/custom_components/hunterdouglas_powerview_ble/button.py
@@ -10,12 +10,12 @@ from homeassistant.components.button import (
     ButtonEntity,
     ButtonEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo, format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import ConfigEntryType, async_setup_shade_platform
 from .const import DOMAIN, LOGGER
 from .coordinator import PVCoordinator
 
@@ -28,16 +28,22 @@ BUTTONS_SHADE: Final = [
 ]
 
 
+def _add_entities(
+    coordinator: PVCoordinator, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Create button entities for a single shade coordinator."""
+    async_add_entities(
+        [PowerViewButton(coordinator, descr) for descr in BUTTONS_SHADE]
+    )
+
+
 async def async_setup_entry(
-    _hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    hass: HomeAssistant,
+    config_entry: ConfigEntryType,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the demo cover platform."""
-
-    coordinator: PVCoordinator = config_entry.runtime_data
-    for descr in BUTTONS_SHADE:
-        async_add_entities([PowerViewButton(coordinator, descr)])
+    """Set up the button platform."""
+    async_setup_shade_platform(hass, config_entry, async_add_entities, _add_entities)
 
 
 class PowerViewButton(PassiveBluetoothCoordinatorEntity[PVCoordinator], ButtonEntity):  # type: ignore[reportIncompatibleVariableOverride]

--- a/custom_components/hunterdouglas_powerview_ble/button.py
+++ b/custom_components/hunterdouglas_powerview_ble/button.py
@@ -32,9 +32,7 @@ def _add_entities(
     coordinator: PVCoordinator, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Create button entities for a single shade coordinator."""
-    async_add_entities(
-        [PowerViewButton(coordinator, descr) for descr in BUTTONS_SHADE]
-    )
+    async_add_entities([PowerViewButton(coordinator, descr) for descr in BUTTONS_SHADE])
 
 
 async def async_setup_entry(

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -2,8 +2,8 @@
 
 import asyncio
 import base64
-import struct
 from dataclasses import dataclass
+import struct
 from typing import Any
 
 import aiohttp
@@ -114,26 +114,26 @@ async def _fetch_key_and_shades_from_hub(
             ) as resp:
                 resp.raise_for_status()
                 result = await resp.json(content_type=None)
-
-            responses = result.get("responses", [])
-            if len(responses) != 1 or "hex" not in responses[0]:
-                continue
-
-            response_bytes = bytes.fromhex(responses[0]["hex"])
-            if len(response_bytes) < 5:
-                continue
-            _s, _c, _q, length = struct.unpack("<BBBB", response_bytes[0:4])
-            if len(response_bytes) != 4 + length:
-                continue
-            if response_bytes[4] != 0:
-                continue
-            key_data = response_bytes[5:]
-            if len(key_data) != 16:
-                continue
-            return key_data, hub_shades
-        except (aiohttp.ClientError, asyncio.TimeoutError) as ex:
+        except (TimeoutError, aiohttp.ClientError) as ex:
             last_error = ex
             continue
+
+        responses = result.get("responses", [])
+        if len(responses) != 1 or "hex" not in responses[0]:
+            continue
+
+        response_bytes = bytes.fromhex(responses[0]["hex"])
+        if len(response_bytes) < 5:
+            continue
+        _s, _c, _q, length = struct.unpack("<BBBB", response_bytes[0:4])
+        if len(response_bytes) != 4 + length:
+            continue
+        if response_bytes[4] != 0:
+            continue
+        key_data = response_bytes[5:]
+        if len(key_data) != 16:
+            continue
+        return key_data, hub_shades
 
     raise ValueError(f"No reachable shade returned a valid key: {last_error}")
 
@@ -205,6 +205,27 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data=data,
         )
 
+    def _validate_manual_key(
+        self, user_input: dict[str, Any], errors: dict[str, str]
+    ) -> bool:
+        """Validate a manually entered hex key and store it.
+
+        Returns True on success, False on validation error.
+        """
+        raw = user_input.get("home_key", "").strip()
+        if "\\x" in raw:
+            raw = raw.replace("\\x", "")
+        if len(raw) != 32:
+            errors["home_key"] = "invalid_key_length"
+            return False
+        try:
+            bytes.fromhex(raw)
+        except ValueError:
+            errors["home_key"] = "invalid_key_format"
+            return False
+        self._home_key = raw.lower()
+        return True
+
     async def _validate_homekey_input(
         self, user_input: dict[str, Any], errors: dict[str, str]
     ) -> bool:
@@ -220,40 +241,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return True
 
         if method == "manual":
-            raw = user_input.get("home_key", "").strip()
-            if "\\x" in raw:
-                raw = raw.replace("\\x", "")
-            if len(raw) != 32:
-                errors["home_key"] = "invalid_key_length"
-                return False
-            try:
-                bytes.fromhex(raw)
-            except ValueError:
-                errors["home_key"] = "invalid_key_format"
-                return False
-            self._home_key = raw.lower()
-            return True
+            return self._validate_manual_key(user_input, errors)
 
-        if method == "hub":
-            hub_url = user_input.get("hub_url", "").rstrip("/")
-            try:
-                key, hub_shades = await _fetch_key_and_shades_from_hub(
-                    self.hass, hub_url
-                )
-                self._home_key = key.hex()
-                self._hub_url = hub_url
-                self._hub_shades = hub_shades
-                return True
-            except aiohttp.ClientResponseError:
-                errors["hub_url"] = "hub_http_error"
-            except aiohttp.ClientConnectionError:
-                errors["hub_url"] = "hub_connection_error"
-            except (asyncio.TimeoutError, TimeoutError):
-                errors["hub_url"] = "hub_timeout"
-            except ValueError:
-                errors["hub_url"] = "hub_protocol_error"
+        if method != "hub":
+            return False
 
-        return False
+        hub_url = user_input.get("hub_url", "").rstrip("/")
+        _HUB_ERROR_MAP: dict[type[Exception], str] = {
+            aiohttp.ClientResponseError: "hub_http_error",
+            aiohttp.ClientConnectionError: "hub_connection_error",
+            TimeoutError: "hub_timeout",
+            ValueError: "hub_protocol_error",
+        }
+        try:
+            key, hub_shades = await _fetch_key_and_shades_from_hub(self.hass, hub_url)
+        except tuple(_HUB_ERROR_MAP) as ex:
+            errors["hub_url"] = _HUB_ERROR_MAP[type(ex)]
+            return False
+
+        self._home_key = key.hex()
+        self._hub_url = hub_url
+        self._hub_shades = hub_shades
+        return True
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -310,13 +319,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors: dict[str, str] = {}
 
-        if user_input is not None:
-            if await self._validate_homekey_input(user_input, errors):
-                # Use hub name for the entry title if available
-                friendly = self._hub_name_for(self._device_name)
-                if friendly:
-                    self._device_name = friendly
-                return self._create_entry()
+        if user_input is not None and await self._validate_homekey_input(
+            user_input, errors
+        ):
+            # Use hub name for the entry title if available
+            friendly = self._hub_name_for(self._device_name)
+            if friendly:
+                self._device_name = friendly
+            return self._create_entry()
 
         return self.async_show_form(
             step_id="homekey_bluetooth",
@@ -349,7 +359,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     break
             if not self._hub_url:
                 self._hub_url = hub_url
-        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
+        except (TimeoutError, aiohttp.ClientError, ValueError):
             pass
 
     def _hub_name_for(self, ble_name: str) -> str | None:
@@ -370,6 +380,35 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_select_device()
         return await self.async_step_homekey()
 
+    def _build_selected_entries(
+        self, user_input: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        """Build config entry data for each selected shade address."""
+        addresses: list[str] = user_input[CONF_ADDRESS]
+        if isinstance(addresses, str):
+            addresses = [addresses]
+
+        entries: list[dict[str, Any]] = []
+        for address in addresses:
+            device = self._discovered_devices[address]
+            ble_name = device.name
+            name = self._hub_name_for(ble_name) or ble_name
+            mfct_hex = device.discovery_info.manufacturer_data[MFCT_ID].hex()
+            entry_data: dict[str, str] = {
+                "manufacturer_data": mfct_hex,
+                CONF_HOME_KEY: self._home_key,
+            }
+            if self._hub_url:
+                entry_data["hub_url"] = self._hub_url
+            entries.append(
+                {
+                    "address": address,
+                    "name": name,
+                    "data": entry_data,
+                }
+            )
+        return entries
+
     async def async_step_select_device(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -377,40 +416,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         LOGGER.debug("select_device step")
 
         if user_input is not None:
-            addresses: list[str] = user_input[CONF_ADDRESS]
-            if isinstance(addresses, str):
-                addresses = [addresses]
-
-            # Build entry info for every selected shade
-            entries: list[dict[str, Any]] = []
-            for address in addresses:
-                device = self._discovered_devices[address]
-                ble_name = device.name
-                name = self._hub_name_for(ble_name) or ble_name
-                mfct_hex = device.discovery_info.manufacturer_data[MFCT_ID].hex()
-                entry_data: dict[str, str] = {
-                    "manufacturer_data": mfct_hex,
-                    CONF_HOME_KEY: self._home_key,
-                }
-                if self._hub_url:
-                    entry_data["hub_url"] = self._hub_url
-                entries.append(
-                    {
-                        "address": address,
-                        "name": name,
-                        "data": entry_data,
-                    }
-                )
+            entries = self._build_selected_entries(user_input)
 
             # Kick off auto-add flows for all but the last shade
-            await asyncio.gather(*(
-                self.hass.config_entries.flow.async_init(
-                    DOMAIN,
-                    context={"source": "auto_add"},
-                    data=info,
+            await asyncio.gather(
+                *(
+                    self.hass.config_entries.flow.async_init(
+                        DOMAIN,
+                        context={"source": "auto_add"},
+                        data=info,
+                    )
+                    for info in entries[:-1]
                 )
-                for info in entries[:-1]
-            ))
+            )
 
             # Create the final entry normally (ends this flow)
             last = entries[-1]
@@ -518,9 +536,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Configure homekey — collected before device selection."""
         errors: dict[str, str] = {}
 
-        if user_input is not None:
-            if await self._validate_homekey_input(user_input, errors):
-                return await self.async_step_select_device()
+        if user_input is not None and await self._validate_homekey_input(
+            user_input, errors
+        ):
+            return await self.async_step_select_device()
 
         return self.async_show_form(
             step_id="homekey",

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -1,9 +1,6 @@
-"""Config flow for BLE Battery Management System integration."""
+"""Config flow for Hunter Douglas PowerView BLE integration."""
 
-import asyncio
-import base64
-import contextlib
-from dataclasses import dataclass
+import hashlib
 import struct
 from typing import Any
 
@@ -11,12 +8,8 @@ import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.bluetooth import (
-    BluetoothServiceInfoBleak,
-    async_discovered_service_info,
-)
+from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
@@ -28,32 +21,78 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .api import UUID_COV_SERVICE as UUID
-from .const import CONF_HOME_KEY, DOMAIN, LOGGER, MFCT_ID
+from .const import CONF_HOME_KEY, CONF_HUB_URL, DOMAIN, LOGGER
 
 
-def _needs_encryption(manufacturer_data_hex: str) -> bool:
-    """Return True if the BLE advertisement indicates encryption (home_id != 0)."""
-    data = bytearray.fromhex(manufacturer_data_hex)
-    if len(data) < 2:
-        return False
-    home_id = int.from_bytes(data[0:2], byteorder="little")
-    return home_id != 0
+def _hub_unique_id(home_key: str) -> str:
+    """Derive a stable unique ID for a hub entry from the home key."""
+    if home_key:
+        digest = hashlib.sha256(home_key.encode()).hexdigest()[:16]
+        return f"pvhome_{digest}"
+    return "pvhome_unencrypted"
 
 
-@dataclass
-class HubShadeInfo:
-    """Shade metadata from the PowerView hub."""
+def _parse_key_response(ble_name: str, result: dict) -> bytes | None:  # noqa: PLR0911
+    """Parse a shade exec response and return the 16-byte key, or None."""
+    if result.get("err"):
+        err_msg = (result.get("responses") or [{}])[0].get("errMsg", "unknown")
+        LOGGER.warning(
+            "Shade %s: hub BLE command failed (err=%s: %s)",
+            ble_name,
+            result["err"],
+            err_msg,
+        )
+        return None
 
-    name: str  # Human-readable name (decoded from base64)
-    ble_name: str  # BLE advertisement name, e.g. "DUE:94ED"
+    responses = result.get("responses", [])
+    if len(responses) != 1 or "hex" not in responses[0]:
+        LOGGER.warning(
+            "Shade %s returned unexpected response structure: %s",
+            ble_name,
+            result,
+        )
+        return None
+
+    response_bytes = bytes.fromhex(responses[0]["hex"])
+    if len(response_bytes) < 5:
+        LOGGER.warning(
+            "Shade %s response too short (%d bytes)", ble_name, len(response_bytes)
+        )
+        return None
+    _s, _c, _q, length = struct.unpack("<BBBB", response_bytes[0:4])
+    if len(response_bytes) != 4 + length:
+        LOGGER.warning(
+            "Shade %s frame length mismatch (header=%d, actual=%d)",
+            ble_name,
+            4 + length,
+            len(response_bytes),
+        )
+        return None
+    if response_bytes[4] != 0:
+        LOGGER.warning(
+            "Shade %s returned error status %d", ble_name, response_bytes[4]
+        )
+        return None
+    key_data = response_bytes[5:]
+    if len(key_data) != 16:
+        LOGGER.warning(
+            "Shade %s returned key of wrong length (%d, expected 16)",
+            ble_name,
+            len(key_data),
+        )
+        return None
+    return key_data
 
 
-async def _fetch_shades_from_hub(
+async def _fetch_key_from_hub(
     hass: HomeAssistant, hub_url: str
-) -> list[HubShadeInfo]:
-    """Fetch shade list with human-readable names from a PowerView G3 hub.
+) -> bytes:
+    """Fetch 16-byte homekey from a PowerView G3 hub.
 
+    Tries each shade on the hub until one returns a valid key.
+    The key is network-wide so any reachable shade returns the same value.
+
+    Raises ValueError on protocol/key errors.
     Raises aiohttp.ClientError on network errors.
     Raises asyncio.TimeoutError on timeout.
     """
@@ -65,76 +104,33 @@ async def _fetch_shades_from_hub(
         shades = await resp.json(content_type=None)
 
     if not shades:
-        return []
-
-    hub_shades: list[HubShadeInfo] = []
-    for shade in shades:
-        ble_name = shade.get("bleName", "")
-        if not ble_name:
-            continue
-        name_b64 = shade.get("name", "")
-        try:
-            name = base64.b64decode(name_b64).decode("utf-8") if name_b64 else ble_name
-        except Exception:  # noqa: BLE001
-            name = ble_name
-        hub_shades.append(HubShadeInfo(name=name, ble_name=ble_name))
-    return hub_shades
-
-
-async def _fetch_key_and_shades_from_hub(
-    hass: HomeAssistant, hub_url: str
-) -> tuple[bytes, list[HubShadeInfo]]:
-    """Fetch 16-byte homekey and shade list from a PowerView G3 hub.
-
-    Returns (key, shade_list).  The key is network-wide so any reachable shade
-    returns the same value.  The shade list contains human-readable names that
-    can be used to label BLE-discovered devices.
-
-    Raises ValueError on protocol/key errors.
-    Raises aiohttp.ClientError on network errors.
-    Raises asyncio.TimeoutError on timeout.
-    """
-    hub_shades = await _fetch_shades_from_hub(hass, hub_url)
-    if not hub_shades:
         raise ValueError("No shades found on the hub")
 
-    session = async_get_clientsession(hass)
-    timeout = aiohttp.ClientTimeout(total=10)
+    ble_names = [s.get("bleName", "") for s in shades if s.get("bleName")]
+    if not ble_names:
+        raise ValueError("No BLE-capable shades found on the hub")
 
     # GetShadeKey BLE request: sid=251, cid=18, seqId=1, data_len=0
     request_frame = struct.pack("<BBBB", 251, 18, 1, 0)
 
-    # Try each shade until one returns a valid key (some may be out of range)
     last_error: Exception = ValueError("No shades responded")
-    for hs in hub_shades:
+    for ble_name in ble_names:
         try:
             async with session.post(
-                f"{hub_url}/home/shades/exec?shades={hs.ble_name}",
+                f"{hub_url}/home/shades/exec?shades={ble_name}",
                 json={"hex": request_frame.hex()},
                 timeout=timeout,
             ) as resp:
                 resp.raise_for_status()
                 result = await resp.json(content_type=None)
         except (TimeoutError, aiohttp.ClientError) as ex:
+            LOGGER.warning("Shade %s unreachable: %s", ble_name, ex)
             last_error = ex
             continue
 
-        responses = result.get("responses", [])
-        if len(responses) != 1 or "hex" not in responses[0]:
-            continue
-
-        response_bytes = bytes.fromhex(responses[0]["hex"])
-        if len(response_bytes) < 5:
-            continue
-        _s, _c, _q, length = struct.unpack("<BBBB", response_bytes[0:4])
-        if len(response_bytes) != 4 + length:
-            continue
-        if response_bytes[4] != 0:
-            continue
-        key_data = response_bytes[5:]
-        if len(key_data) != 16:
-            continue
-        return key_data, hub_shades
+        key_data = _parse_key_response(ble_name, result)
+        if key_data is not None:
+            return key_data
 
     raise ValueError(f"No reachable shade returned a valid key: {last_error}")
 
@@ -159,7 +155,7 @@ _HOMEKEY_SCHEMA = vol.Schema(
                 ]
             )
         ),
-        vol.Optional("hub_url", default="http://powerview-g3.local"): TextSelector(
+        vol.Optional(CONF_HUB_URL, default="http://powerview-g3.local"): TextSelector(
             TextSelectorConfig(type=TextSelectorType.URL)
         ),
         vol.Optional("home_key", default=""): TextSelector(
@@ -170,46 +166,27 @@ _HOMEKEY_SCHEMA = vol.Schema(
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for BT Battery Management System."""
+    """Handle a config flow for Hunter Douglas PowerView BLE."""
 
-    VERSION = 1
+    VERSION = 2
     MINOR_VERSION = 1
-
-    @dataclass
-    class DiscoveredDevice:
-        """A discovered bluetooth device."""
-
-        name: str
-        discovery_info: BluetoothServiceInfoBleak
 
     def __init__(self) -> None:
         """Initialize the config flow."""
-
-        self._discovered_device: ConfigFlow.DiscoveredDevice | None = None
-        self._discovered_devices: dict[str, ConfigFlow.DiscoveredDevice] = {}
-        self._manufacturer_data_hex: str = ""
-        self._device_name: str = ""
         self._home_key: str = ""
         self._hub_url: str = ""
-        self._hub_shades: list[HubShadeInfo] = []
 
     def _create_entry(self) -> ConfigFlowResult:
-        """Create the config entry with collected data."""
-        data: dict[str, str] = {
-            "manufacturer_data": self._manufacturer_data_hex,
-            CONF_HOME_KEY: self._home_key,
-        }
+        """Create the hub config entry."""
+        data: dict[str, str] = {CONF_HOME_KEY: self._home_key}
         if self._hub_url:
-            data["hub_url"] = self._hub_url
-        return self.async_create_entry(
-            title=self._device_name,
-            data=data,
-        )
+            data[CONF_HUB_URL] = self._hub_url
+        return self.async_create_entry(title="PowerView Home", data=data)
 
     def _validate_manual_key(
         self, user_input: dict[str, Any], errors: dict[str, str]
     ) -> bool:
-        """Validate a manually entered hex key and store it.
+        """Validate a manually entered hex key.
 
         Returns True on success, False on validation error.
         """
@@ -233,7 +210,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Parse and validate homekey user_input, populating self state.
 
         Returns True on success, False on validation error (errors dict is populated).
-        On skip, self._home_key is set to "".
         """
         method = user_input.get("key_method", "skip")
 
@@ -247,7 +223,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if method != "hub":
             return False
 
-        hub_url = user_input.get("hub_url", "").rstrip("/")
+        hub_url = user_input.get(CONF_HUB_URL, "").rstrip("/")
         _HUB_ERROR_MAP: dict[type[Exception], str] = {
             aiohttp.ClientResponseError: "hub_http_error",
             aiohttp.ClientConnectionError: "hub_connection_error",
@@ -255,14 +231,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ValueError: "hub_protocol_error",
         }
         try:
-            key, hub_shades = await _fetch_key_and_shades_from_hub(self.hass, hub_url)
+            key = await _fetch_key_from_hub(self.hass, hub_url)
         except tuple(_HUB_ERROR_MAP) as ex:
-            errors["hub_url"] = _HUB_ERROR_MAP[type(ex)]
+            LOGGER.warning("Hub key fetch failed: %s", ex)
+            errors[CONF_HUB_URL] = _HUB_ERROR_MAP[type(ex)]
             return False
 
         self._home_key = key.hex()
         self._hub_url = hub_url
-        self._hub_shades = hub_shades
         return True
 
     async def async_step_bluetooth(
@@ -271,296 +247,45 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by Bluetooth discovery."""
         LOGGER.debug("Bluetooth device detected: %s", discovery_info)
 
+        # Tag the flow with this address so HA deduplicates future
+        # discovery flows for the same device
         await self.async_set_unique_id(discovery_info.address)
-        self._abort_if_unique_id_configured()
 
-        self._discovered_device = ConfigFlow.DiscoveredDevice(
-            discovery_info.name, discovery_info
-        )
-        self.context["title_placeholders"] = {"name": self._discovered_device.name}
-        return await self.async_step_bluetooth_confirm()
-
-    async def async_step_bluetooth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Confirm bluetooth device discovery."""
-        assert self._discovered_device is not None
-        LOGGER.debug("confirm step for %s", self._discovered_device.name)
-
-        if user_input is not None:
-            self._manufacturer_data_hex = (
-                self._discovered_device.discovery_info.manufacturer_data[MFCT_ID].hex()
-            )
-            self._device_name = self._discovered_device.name
-
-            # Unencrypted shades can skip the homekey step entirely
-            if not _needs_encryption(self._manufacturer_data_hex):
-                await self._resolve_friendly_name()
-                return self._create_entry()
-
-            return await self.async_step_homekey_bluetooth()
-
-        self._set_confirm_only()
-
-        return self.async_show_form(
-            step_id="bluetooth_confirm",
-            description_placeholders={"name": self._discovered_device.name},
-        )
-
-    async def async_step_homekey_bluetooth(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Configure homekey for a shade discovered via Bluetooth."""
-        # Reuse an existing key if another shade was already configured
-        existing = self._existing_home_key()
-        if existing and user_input is None:
-            self._home_key = existing
-            await self._resolve_friendly_name()
-            return self._create_entry()
-
-        errors: dict[str, str] = {}
-
-        if user_input is not None and await self._validate_homekey_input(
-            user_input, errors
-        ):
-            # Use hub name for the entry title if available
-            friendly = self._hub_name_for(self._device_name)
-            if friendly:
-                self._device_name = friendly
-            return self._create_entry()
-
-        return self.async_show_form(
-            step_id="homekey_bluetooth",
-            data_schema=_HOMEKEY_SCHEMA,
-            errors=errors,
-            description_placeholders={
-                "name": self._device_name,
-                "hub_url_example": "http://powerview-g3.local",
-            },
-        )
-
-    def _existing_entry_value(self, key: str) -> str:
-        """Return the first non-empty value for *key* across configured entries."""
+        # If a hub entry already exists, shades are auto-discovered
         for entry in self._async_current_entries():
-            if value := entry.data.get(key, ""):
-                return value
-        return ""
+            if entry.version >= 2:
+                return self.async_abort(reason="already_configured")
 
-    def _existing_home_key(self) -> str:
-        """Return the home_key from any already-configured entry, or ''."""
-        return self._existing_entry_value(CONF_HOME_KEY)
-
-    async def _resolve_friendly_name(self) -> None:
-        """Try to resolve BLE device name to hub friendly name."""
-        hub_url = self._hub_url or self._existing_entry_value("hub_url")
-        if not hub_url:
-            return
-        try:
-            shades = await _fetch_shades_from_hub(self.hass, hub_url)
-            for hs in shades:
-                if hs.ble_name == self._device_name:
-                    self._device_name = hs.name
-                    break
-            if not self._hub_url:
-                self._hub_url = hub_url
-        except (TimeoutError, aiohttp.ClientError, ValueError):
-            pass
-
-    def _hub_name_for(self, ble_name: str) -> str | None:
-        """Return the human-readable hub name for a BLE name, or None."""
-        for hs in self._hub_shades:
-            if hs.ble_name == ble_name:
-                return hs.name
-        return None
+        # No hub entry yet — redirect to user setup
+        return await self.async_step_user()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the user step — reuse existing key or offer a menu."""
+        """Handle the user step — create a hub entry."""
         LOGGER.debug("user step")
-        existing = self._existing_home_key()
-        if existing:
-            self._home_key = existing
-            self._hub_url = self._hub_url or self._existing_entry_value("hub_url")
-            if self._hub_url and not self._hub_shades:
-                with contextlib.suppress(
-                    TimeoutError, aiohttp.ClientError, ValueError
-                ):
-                    self._hub_shades = await _fetch_shades_from_hub(
-                        self.hass, self._hub_url
-                    )
-            return self.async_show_menu(
-                step_id="user",
-                menu_options=["select_device", "manual"],
-            )
-        return await self.async_step_homekey()
 
-    def _build_selected_entries(
-        self, user_input: dict[str, Any]
-    ) -> list[dict[str, Any]]:
-        """Build config entry data for each selected shade address."""
-        addresses: list[str] = user_input[CONF_ADDRESS]
-        if isinstance(addresses, str):
-            addresses = [addresses]
+        # Only one hub entry allowed (per key, but for simplicity one total)
+        for entry in self._async_current_entries():
+            if entry.version >= 2:
+                return self.async_abort(reason="single_instance_allowed")
 
-        entries: list[dict[str, Any]] = []
-        for address in addresses:
-            device = self._discovered_devices[address]
-            ble_name = device.name
-            name = self._hub_name_for(ble_name) or ble_name
-            mfct_hex = device.discovery_info.manufacturer_data[MFCT_ID].hex()
-            entry_data: dict[str, str] = {
-                "manufacturer_data": mfct_hex,
-                CONF_HOME_KEY: self._home_key,
-            }
-            if self._hub_url:
-                entry_data["hub_url"] = self._hub_url
-            entries.append(
-                {
-                    "address": address,
-                    "name": name,
-                    "data": entry_data,
-                }
-            )
-        return entries
-
-    async def async_step_select_device(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Select one or more BLE-discovered shades, or fall through to manual."""
-        LOGGER.debug("select_device step")
-
-        if user_input is not None:
-            entries = self._build_selected_entries(user_input)
-
-            # Kick off auto-add flows for all but the last shade
-            await asyncio.gather(
-                *(
-                    self.hass.config_entries.flow.async_init(
-                        DOMAIN,
-                        context={"source": "auto_add"},
-                        data=info,
-                    )
-                    for info in entries[:-1]
-                )
-            )
-
-            # Create the final entry normally (ends this flow)
-            last = entries[-1]
-            await self.async_set_unique_id(last["address"], raise_on_progress=False)
-            self._abort_if_unique_id_configured()
-            self._device_name = last["name"]
-            self._manufacturer_data_hex = last["data"]["manufacturer_data"]
-            self.context["title_placeholders"] = {"name": self._device_name}
-            return self._create_entry()
-
-        current_addresses = self._async_current_ids()
-        for discovery_info in async_discovered_service_info(self.hass, False):
-            address = discovery_info.address
-            if address in current_addresses or address in self._discovered_devices:
-                continue
-
-            if MFCT_ID not in discovery_info.manufacturer_data:
-                continue
-
-            if UUID not in discovery_info.service_uuids:
-                continue
-
-            self._discovered_devices[address] = ConfigFlow.DiscoveredDevice(
-                discovery_info.name, discovery_info
-            )
-
-        if not self._discovered_devices:
-            return await self.async_step_manual()
-
-        titles: list[SelectOptionDict] = []
-        for address, discovery in self._discovered_devices.items():
-            hub_name = self._hub_name_for(discovery.name)
-            label = f"{hub_name} ({discovery.name})" if hub_name else discovery.name
-            titles.append({"value": address, "label": label})
-
-        return self.async_show_form(
-            step_id="select_device",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_ADDRESS): SelectSelector(
-                        SelectSelectorConfig(options=titles, multiple=True)
-                    )
-                }
-            ),
-        )
-
-    async def async_step_auto_add(
-        self, discovery_info: dict[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle a shade queued from multi-select for individual setup."""
-        await self.async_set_unique_id(discovery_info["address"])
-        self._abort_if_unique_id_configured()
-
-        self._device_name = discovery_info["name"]
-        self._manufacturer_data_hex = discovery_info["data"]["manufacturer_data"]
-        self._home_key = discovery_info["data"].get(CONF_HOME_KEY, "")
-        self._hub_url = discovery_info["data"].get("hub_url", "")
-
-        self.context["title_placeholders"] = {"name": self._device_name}
-        return await self.async_step_auto_add_confirm()
-
-    async def async_step_auto_add_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Confirm adding a shade discovered via multi-select."""
-        if user_input is not None:
-            return self._create_entry()
-
-        self._set_confirm_only()
-        return self.async_show_form(
-            step_id="auto_add_confirm",
-            description_placeholders={"name": self._device_name},
-        )
-
-    async def async_step_manual(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle manual entry of a BLE device address and name."""
-        if user_input is not None:
-            address = user_input[CONF_ADDRESS].upper().strip()
-            self._device_name = user_input["ble_name"].strip()
-            await self.async_set_unique_id(address, raise_on_progress=False)
-            self._abort_if_unique_id_configured()
-            self.context["title_placeholders"] = {"name": self._device_name}
-            self._manufacturer_data_hex = ""
-            return self._create_entry()
-
-        return self.async_show_form(
-            step_id="manual",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_ADDRESS): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.TEXT)
-                    ),
-                    vol.Required("ble_name"): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.TEXT)
-                    ),
-                }
-            ),
-        )
-
-    async def async_step_homekey(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Configure homekey — collected before device selection."""
         errors: dict[str, str] = {}
 
         if user_input is not None and await self._validate_homekey_input(
             user_input, errors
         ):
-            return await self.async_step_select_device()
+            unique_id = _hub_unique_id(self._home_key)
+            await self.async_set_unique_id(unique_id, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            return self._create_entry()
 
         return self.async_show_form(
-            step_id="homekey",
+            step_id="user",
             data_schema=_HOMEKEY_SCHEMA,
             errors=errors,
             description_placeholders={
                 "hub_url_example": "http://powerview-g3.local",
             },
         )
+

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import contextlib
 from dataclasses import dataclass
 import struct
 from typing import Any
@@ -372,12 +373,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the user step — reuse existing key or collect one."""
+        """Handle the user step — reuse existing key or offer a menu."""
         LOGGER.debug("user step")
         existing = self._existing_home_key()
         if existing:
             self._home_key = existing
-            return await self.async_step_select_device()
+            self._hub_url = self._hub_url or self._existing_entry_value("hub_url")
+            if self._hub_url and not self._hub_shades:
+                with contextlib.suppress(
+                    TimeoutError, aiohttp.ClientError, ValueError
+                ):
+                    self._hub_shades = await _fetch_shades_from_hub(
+                        self.hass, self._hub_url
+                    )
+            return self.async_show_menu(
+                step_id="user",
+                menu_options=["select_device", "manual"],
+            )
         return await self.async_step_homekey()
 
     def _build_selected_entries(

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -1,8 +1,12 @@
 """Config flow for BLE Battery Management System integration."""
 
+import asyncio
+import base64
+import struct
 from dataclasses import dataclass
 from typing import Any
 
+import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -12,21 +16,121 @@ from homeassistant.components.bluetooth import (
 )
 from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_ADDRESS
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
 )
 
 from .api import UUID_COV_SERVICE as UUID
-from .const import DOMAIN, LOGGER, MFCT_ID
+from .const import CONF_HOME_KEY, DOMAIN, LOGGER, MFCT_ID
+
+
+def _needs_encryption(manufacturer_data_hex: str) -> bool:
+    """Return True if the BLE advertisement indicates encryption (home_id != 0)."""
+    data = bytearray.fromhex(manufacturer_data_hex)
+    if len(data) < 2:
+        return False
+    home_id = int.from_bytes(data[0:2], byteorder="little")
+    return home_id != 0
+
+
+@dataclass
+class HubShadeInfo:
+    """Shade metadata from the PowerView hub."""
+
+    name: str  # Human-readable name (decoded from base64)
+    ble_name: str  # BLE advertisement name, e.g. "DUE:94ED"
+
+
+async def _fetch_key_and_shades_from_hub(
+    hass: HomeAssistant, hub_url: str
+) -> tuple[bytes, list[HubShadeInfo]]:
+    """Fetch 16-byte homekey and shade list from a PowerView G3 hub.
+
+    Returns (key, shade_list).  The key is network-wide so any reachable shade
+    returns the same value.  The shade list contains human-readable names that
+    can be used to label BLE-discovered devices.
+
+    Raises ValueError on protocol/key errors.
+    Raises aiohttp.ClientError on network errors.
+    Raises asyncio.TimeoutError on timeout.
+    """
+    session = async_get_clientsession(hass)
+    timeout = aiohttp.ClientTimeout(total=10)
+
+    # Get list of shades from hub
+    async with session.get(f"{hub_url}/home/shades", timeout=timeout) as resp:
+        resp.raise_for_status()
+        shades = await resp.json(content_type=None)
+
+    if not shades:
+        raise ValueError("No shades found on the hub")
+
+    # Parse shade metadata (name is base64-encoded on the hub)
+    hub_shades: list[HubShadeInfo] = []
+    for shade in shades:
+        ble_name = shade.get("bleName", "")
+        if not ble_name:
+            continue
+        name_b64 = shade.get("name", "")
+        try:
+            name = base64.b64decode(name_b64).decode("utf-8") if name_b64 else ble_name
+        except Exception:  # noqa: BLE001
+            name = ble_name
+        hub_shades.append(HubShadeInfo(name=name, ble_name=ble_name))
+
+    # GetShadeKey BLE request: sid=251, cid=18, seqId=1, data_len=0
+    request_frame = struct.pack("<BBBB", 251, 18, 1, 0)
+
+    # Try each shade until one returns a valid key (some may be out of range)
+    last_error: Exception = ValueError("No shades responded")
+    for shade in shades:
+        ble_name = shade.get("bleName", "")
+        if not ble_name:
+            continue
+        try:
+            async with session.post(
+                f"{hub_url}/home/shades/exec?shades={ble_name}",
+                json={"hex": request_frame.hex()},
+                timeout=timeout,
+            ) as resp:
+                resp.raise_for_status()
+                result = await resp.json(content_type=None)
+
+            responses = result.get("responses", [])
+            if len(responses) != 1 or "hex" not in responses[0]:
+                continue
+
+            response_bytes = bytes.fromhex(responses[0]["hex"])
+            if len(response_bytes) < 5:
+                continue
+            _s, _c, _q, length = struct.unpack("<BBBB", response_bytes[0:4])
+            if len(response_bytes) != 4 + length:
+                continue
+            if response_bytes[4] != 0:
+                continue
+            key_data = response_bytes[5:]
+            if len(key_data) != 16:
+                continue
+            return key_data, hub_shades
+        except (aiohttp.ClientError, asyncio.TimeoutError) as ex:
+            last_error = ex
+            continue
+
+    raise ValueError(f"No reachable shade returned a valid key: {last_error}")
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for BT Battery Management System."""
 
     VERSION = 1
-    MINOR_VERSION = 0
+    MINOR_VERSION = 1
 
     @dataclass
     class DiscoveredDevice:
@@ -40,6 +144,20 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._discovered_device: ConfigFlow.DiscoveredDevice | None = None
         self._discovered_devices: dict[str, ConfigFlow.DiscoveredDevice] = {}
+        self._manufacturer_data_hex: str = ""
+        self._device_name: str = ""
+        self._home_key: str = ""
+        self._hub_shades: list[HubShadeInfo] = []
+
+    def _create_entry(self) -> ConfigFlowResult:
+        """Create the config entry with collected data."""
+        return self.async_create_entry(
+            title=self._device_name,
+            data={
+                "manufacturer_data": self._manufacturer_data_hex,
+                CONF_HOME_KEY: self._home_key,
+            },
+        )
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -64,14 +182,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         LOGGER.debug("confirm step for %s", self._discovered_device.name)
 
         if user_input is not None:
-            return self.async_create_entry(
-                title=self._discovered_device.name,
-                data={
-                    "manufacturer_data": self._discovered_device.discovery_info.manufacturer_data[
-                        MFCT_ID
-                    ].hex()
-                },
+            self._manufacturer_data_hex = (
+                self._discovered_device.discovery_info.manufacturer_data[MFCT_ID].hex()
             )
+            self._device_name = self._discovered_device.name
+
+            # Unencrypted shades can skip the homekey step entirely
+            if not _needs_encryption(self._manufacturer_data_hex):
+                return self._create_entry()
+
+            return await self.async_step_homekey_bluetooth()
 
         self._set_confirm_only()
 
@@ -80,28 +200,167 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={"name": self._discovered_device.name},
         )
 
+    async def async_step_homekey_bluetooth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Configure homekey for a shade discovered via Bluetooth."""
+        # Reuse an existing key if another shade was already configured
+        existing = self._existing_home_key()
+        if existing and user_input is None:
+            self._home_key = existing
+            return self._create_entry()
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            method = user_input.get("key_method", "skip")
+
+            if method == "skip":
+                self._home_key = ""
+                return self._create_entry()
+
+            elif method == "manual":
+                raw = user_input.get("home_key", "").strip()
+                if "\\x" in raw:
+                    raw = raw.replace("\\x", "")
+                if len(raw) != 32:
+                    errors["home_key"] = "invalid_key_length"
+                else:
+                    try:
+                        bytes.fromhex(raw)
+                    except ValueError:
+                        errors["home_key"] = "invalid_key_format"
+                    else:
+                        self._home_key = raw.lower()
+                        return self._create_entry()
+
+            elif method == "hub":
+                hub_url = user_input.get("hub_url", "").rstrip("/")
+                try:
+                    key, hub_shades = await _fetch_key_and_shades_from_hub(
+                        self.hass, hub_url
+                    )
+                    self._home_key = key.hex()
+                    # Use hub name for the entry title if available
+                    for hs in hub_shades:
+                        if hs.ble_name == self._device_name:
+                            self._device_name = hs.name
+                            break
+                    return self._create_entry()
+                except aiohttp.ClientResponseError:
+                    errors["hub_url"] = "hub_http_error"
+                except aiohttp.ClientConnectionError:
+                    errors["hub_url"] = "hub_connection_error"
+                except (asyncio.TimeoutError, TimeoutError):
+                    errors["hub_url"] = "hub_timeout"
+                except ValueError:
+                    errors["hub_url"] = "hub_protocol_error"
+
+        return self.async_show_form(
+            step_id="homekey_bluetooth",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("key_method", default="hub"): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                {
+                                    "value": "hub",
+                                    "label": "Fetch automatically from PowerView hub",
+                                },
+                                {
+                                    "value": "manual",
+                                    "label": "Enter key manually (32 hex characters)",
+                                },
+                                {
+                                    "value": "skip",
+                                    "label": "Skip (no key — controls disabled for encrypted shades)",
+                                },
+                            ]
+                        )
+                    ),
+                    vol.Optional("hub_url", default="http://powerview-g3.local"): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.URL)
+                    ),
+                    vol.Optional("home_key", default=""): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.TEXT)
+                    ),
+                }
+            ),
+            errors=errors,
+            description_placeholders={"name": self._device_name},
+        )
+
+    def _existing_home_key(self) -> str:
+        """Return the home_key from any already-configured entry, or ''."""
+        for entry in self._async_current_entries():
+            key = entry.data.get(CONF_HOME_KEY, "")
+            if key:
+                return key
+        return ""
+
+    def _hub_name_for(self, ble_name: str) -> str | None:
+        """Return the human-readable hub name for a BLE name, or None."""
+        for hs in self._hub_shades:
+            if hs.ble_name == ble_name:
+                return hs.name
+        return None
+
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the user step to pick discovered device."""
+        """Handle the user step — reuse existing key or collect one."""
         LOGGER.debug("user step")
+        existing = self._existing_home_key()
+        if existing:
+            self._home_key = existing
+            return await self.async_step_select_device()
+        return await self.async_step_homekey()
+
+    async def async_step_select_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Select one or more BLE-discovered shades, or fall through to manual."""
+        LOGGER.debug("select_device step")
 
         if user_input is not None:
-            address = user_input[CONF_ADDRESS]
-            await self.async_set_unique_id(address, raise_on_progress=False)
+            addresses: list[str] = user_input[CONF_ADDRESS]
+            if isinstance(addresses, str):
+                addresses = [addresses]
+
+            # Build entry info for every selected shade
+            entries: list[dict[str, Any]] = []
+            for address in addresses:
+                device = self._discovered_devices[address]
+                ble_name = device.name
+                name = self._hub_name_for(ble_name) or ble_name
+                mfct_hex = device.discovery_info.manufacturer_data[MFCT_ID].hex()
+                entries.append(
+                    {
+                        "address": address,
+                        "name": name,
+                        "data": {
+                            "manufacturer_data": mfct_hex,
+                            CONF_HOME_KEY: self._home_key,
+                        },
+                    }
+                )
+
+            # Kick off auto-add flows for all but the last shade
+            for info in entries[:-1]:
+                await self.hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": "auto_add"},
+                    data=info,
+                )
+
+            # Create the final entry normally (ends this flow)
+            last = entries[-1]
+            await self.async_set_unique_id(last["address"], raise_on_progress=False)
             self._abort_if_unique_id_configured()
-            self._discovered_device = self._discovered_devices[address]
-
-            self.context["title_placeholders"] = {"name": self._discovered_device.name}
-
-            return self.async_create_entry(
-                title=self._discovered_device.name,
-                data={
-                    "manufacturer_data": self._discovered_device.discovery_info.manufacturer_data[
-                        MFCT_ID
-                    ].hex()
-                },
-            )
+            self._device_name = last["name"]
+            self._manufacturer_data_hex = last["data"]["manufacturer_data"]
+            self.context["title_placeholders"] = {"name": self._device_name}
+            return self._create_entry()
 
         current_addresses = self._async_current_ids()
         for discovery_info in async_discovered_service_info(self.hass, False):
@@ -120,19 +379,136 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         if not self._discovered_devices:
-            return self.async_abort(reason="no_devices_found")
+            return await self.async_step_manual()
 
         titles: list[SelectOptionDict] = []
         for address, discovery in self._discovered_devices.items():
-            titles.append({"value": address, "label": discovery.name})
+            hub_name = self._hub_name_for(discovery.name)
+            label = f"{hub_name} ({discovery.name})" if hub_name else discovery.name
+            titles.append({"value": address, "label": label})
 
         return self.async_show_form(
-            step_id="user",
+            step_id="select_device",
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_ADDRESS): SelectSelector(
-                        SelectSelectorConfig(options=titles)
+                        SelectSelectorConfig(options=titles, multiple=True)
                     )
                 }
             ),
+        )
+
+    async def async_step_auto_add(
+        self, data: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Create a config entry for a shade selected via multi-select."""
+        await self.async_set_unique_id(data["address"])
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title=data["name"], data=data["data"])
+
+    async def async_step_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle manual entry of a BLE device address and name."""
+        if user_input is not None:
+            address = user_input[CONF_ADDRESS].upper().strip()
+            self._device_name = user_input["ble_name"].strip()
+            await self.async_set_unique_id(address, raise_on_progress=False)
+            self._abort_if_unique_id_configured()
+            self.context["title_placeholders"] = {"name": self._device_name}
+            self._manufacturer_data_hex = ""
+            return self._create_entry()
+
+        return self.async_show_form(
+            step_id="manual",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ADDRESS): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.TEXT)
+                    ),
+                    vol.Required("ble_name"): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.TEXT)
+                    ),
+                }
+            ),
+        )
+
+    async def async_step_homekey(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Configure homekey — collected before device selection."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            method = user_input.get("key_method", "skip")
+
+            if method == "skip":
+                self._home_key = ""
+                return await self.async_step_select_device()
+
+            elif method == "manual":
+                raw = user_input.get("home_key", "").strip()
+                # Accept \xNN\xNN... format (e.g. from ESP32 emulator serial log)
+                if "\\x" in raw:
+                    raw = raw.replace("\\x", "")
+                if len(raw) != 32:
+                    errors["home_key"] = "invalid_key_length"
+                else:
+                    try:
+                        bytes.fromhex(raw)
+                    except ValueError:
+                        errors["home_key"] = "invalid_key_format"
+                    else:
+                        self._home_key = raw.lower()
+                        return await self.async_step_select_device()
+
+            elif method == "hub":
+                hub_url = user_input.get("hub_url", "").rstrip("/")
+                try:
+                    key, hub_shades = await _fetch_key_and_shades_from_hub(
+                        self.hass, hub_url
+                    )
+                    self._home_key = key.hex()
+                    self._hub_shades = hub_shades
+                    return await self.async_step_select_device()
+                except aiohttp.ClientResponseError:
+                    errors["hub_url"] = "hub_http_error"
+                except aiohttp.ClientConnectionError:
+                    errors["hub_url"] = "hub_connection_error"
+                except (asyncio.TimeoutError, TimeoutError):
+                    errors["hub_url"] = "hub_timeout"
+                except ValueError:
+                    errors["hub_url"] = "hub_protocol_error"
+
+        return self.async_show_form(
+            step_id="homekey",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("key_method", default="hub"): SelectSelector(
+                        SelectSelectorConfig(
+                            options=[
+                                {
+                                    "value": "hub",
+                                    "label": "Fetch automatically from PowerView hub",
+                                },
+                                {
+                                    "value": "manual",
+                                    "label": "Enter key manually (32 hex characters)",
+                                },
+                                {
+                                    "value": "skip",
+                                    "label": "Skip (no key — controls disabled for encrypted shades)",
+                                },
+                            ]
+                        )
+                    ),
+                    vol.Optional("hub_url", default="http://powerview-g3.local"): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.URL)
+                    ),
+                    vol.Optional("home_key", default=""): TextSelector(
+                        TextSelectorConfig(type=TextSelectorType.TEXT)
+                    ),
+                }
+            ),
+            errors=errors,
         )

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -144,18 +144,18 @@ _HOMEKEY_SCHEMA = vol.Schema(
         vol.Required("key_method", default="hub"): SelectSelector(
             SelectSelectorConfig(
                 options=[
-                    {
-                        "value": "hub",
-                        "label": "Fetch automatically from PowerView hub",
-                    },
-                    {
-                        "value": "manual",
-                        "label": "Enter key manually (32 hex characters)",
-                    },
-                    {
-                        "value": "skip",
-                        "label": "Skip (no key — controls disabled for encrypted shades)",
-                    },
+                    SelectOptionDict(
+                        value="hub",
+                        label="Fetch automatically from PowerView hub",
+                    ),
+                    SelectOptionDict(
+                        value="manual",
+                        label="Enter key manually (32 hex characters)",
+                    ),
+                    SelectOptionDict(
+                        value="skip",
+                        label="Skip (no key — controls disabled for encrypted shades)",
+                    ),
                 ]
             )
         ),
@@ -333,7 +333,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="homekey_bluetooth",
             data_schema=_HOMEKEY_SCHEMA,
             errors=errors,
-            description_placeholders={"name": self._device_name},
+            description_placeholders={
+                "name": self._device_name,
+                "hub_url_example": "http://powerview-g3.local",
+            },
         )
 
     def _existing_entry_value(self, key: str) -> str:
@@ -557,4 +560,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="homekey",
             data_schema=_HOMEKEY_SCHEMA,
             errors=errors,
+            description_placeholders={
+                "hub_url_example": "http://powerview-g3.local",
+            },
         )

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -458,13 +458,31 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_auto_add(
-        self, user_input: dict[str, Any]
+        self, discovery_info: dict[str, Any]
     ) -> ConfigFlowResult:
-        """Create a config entry for a shade selected via multi-select."""
-        await self.async_set_unique_id(user_input["address"])
+        """Handle a shade queued from multi-select for individual setup."""
+        await self.async_set_unique_id(discovery_info["address"])
         self._abort_if_unique_id_configured()
-        return self.async_create_entry(
-            title=user_input["name"], data=user_input["data"]
+
+        self._device_name = discovery_info["name"]
+        self._manufacturer_data_hex = discovery_info["data"]["manufacturer_data"]
+        self._home_key = discovery_info["data"].get(CONF_HOME_KEY, "")
+        self._hub_url = discovery_info["data"].get("hub_url", "")
+
+        self.context["title_placeholders"] = {"name": self._device_name}
+        return await self.async_step_auto_add_confirm()
+
+    async def async_step_auto_add_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm adding a shade discovered via multi-select."""
+        if user_input is not None:
+            return self._create_entry()
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="auto_add_confirm",
+            description_placeholders={"name": self._device_name},
         )
 
     async def async_step_manual(

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -111,7 +111,10 @@ async def _fetch_key_from_hub(
     if not shades:
         raise ValueError("No shades found on the hub")
 
-    ble_names = [s.get("bleName", "") for s in shades if s.get("bleName")]
+    # Sort by signal strength (strongest first) — a stronger signal means the
+    # hub is more likely to have an active BLE connection to that shade.
+    shades.sort(key=lambda s: s.get("signalStrength", -100), reverse=True)
+    ble_names = [s["bleName"] for s in shades if s.get("bleName")]
     if not ble_names:
         raise ValueError("No BLE-capable shades found on the hub")
 

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.selector import (
     TextSelectorType,
 )
 
-from .const import CONF_HOME_KEY, CONF_HUB_URL, DOMAIN, LOGGER
+from .const import CONF_HOME_KEY, CONF_HUB_URL, DOMAIN, LOGGER, MFCT_ID
 
 
 def _hub_unique_id(home_key: str) -> str:
@@ -91,6 +91,11 @@ async def _fetch_key_from_hub(
 
     Tries each shade on the hub until one returns a valid key.
     The key is network-wide so any reachable shade returns the same value.
+
+    The hub must establish a BLE connection to each shade before it can proxy
+    the key request.  On the first pass that connection is often not yet open,
+    so the hub returns an error immediately.  A second pass (after a short
+    pause to let the hub complete its BLE connections) reliably succeeds.
 
     Raises ValueError on protocol/key errors.
     Raises aiohttp.ClientError on network errors.
@@ -247,11 +252,25 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle a flow initialized by Bluetooth discovery."""
         LOGGER.debug("Bluetooth device detected: %s", discovery_info)
 
-        # Tag the flow with this address so HA deduplicates future
-        # discovery flows for the same device
-        await self.async_set_unique_id(discovery_info.address)
+        # Derive a home-wide unique ID from the home_id embedded in the BLE
+        # advertisement (bytes 0-1 of the manufacturer payload).  All shades on
+        # the same network share the same home_id, so HA deduplicates every
+        # subsequent shade discovery into this single flow via
+        # "already_in_progress" rather than spawning one notification per shade.
+        mfr_data = bytearray(
+            discovery_info.manufacturer_data.get(MFCT_ID, b"")
+        )
+        if len(mfr_data) >= 2:
+            home_id = int.from_bytes(mfr_data[0:2], byteorder="little")
+            unique_id = f"pvhome_{home_id}"
+        else:
+            unique_id = DOMAIN
 
-        # If a hub entry already exists, shades are auto-discovered
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        # If a hub entry already exists (unique_id may differ), shades are
+        # auto-discovered internally — nothing more for the user to do.
         for entry in self._async_current_entries():
             if entry.version >= 2:
                 return self.async_abort(reason="already_configured")

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -48,6 +48,38 @@ class HubShadeInfo:
     ble_name: str  # BLE advertisement name, e.g. "DUE:94ED"
 
 
+async def _fetch_shades_from_hub(
+    hass: HomeAssistant, hub_url: str
+) -> list[HubShadeInfo]:
+    """Fetch shade list with human-readable names from a PowerView G3 hub.
+
+    Raises aiohttp.ClientError on network errors.
+    Raises asyncio.TimeoutError on timeout.
+    """
+    session = async_get_clientsession(hass)
+    timeout = aiohttp.ClientTimeout(total=10)
+
+    async with session.get(f"{hub_url}/home/shades", timeout=timeout) as resp:
+        resp.raise_for_status()
+        shades = await resp.json(content_type=None)
+
+    if not shades:
+        return []
+
+    hub_shades: list[HubShadeInfo] = []
+    for shade in shades:
+        ble_name = shade.get("bleName", "")
+        if not ble_name:
+            continue
+        name_b64 = shade.get("name", "")
+        try:
+            name = base64.b64decode(name_b64).decode("utf-8") if name_b64 else ble_name
+        except Exception:  # noqa: BLE001
+            name = ble_name
+        hub_shades.append(HubShadeInfo(name=name, ble_name=ble_name))
+    return hub_shades
+
+
 async def _fetch_key_and_shades_from_hub(
     hass: HomeAssistant, hub_url: str
 ) -> tuple[bytes, list[HubShadeInfo]]:
@@ -61,42 +93,22 @@ async def _fetch_key_and_shades_from_hub(
     Raises aiohttp.ClientError on network errors.
     Raises asyncio.TimeoutError on timeout.
     """
-    session = async_get_clientsession(hass)
-    timeout = aiohttp.ClientTimeout(total=10)
-
-    # Get list of shades from hub
-    async with session.get(f"{hub_url}/home/shades", timeout=timeout) as resp:
-        resp.raise_for_status()
-        shades = await resp.json(content_type=None)
-
-    if not shades:
+    hub_shades = await _fetch_shades_from_hub(hass, hub_url)
+    if not hub_shades:
         raise ValueError("No shades found on the hub")
 
-    # Parse shade metadata (name is base64-encoded on the hub)
-    hub_shades: list[HubShadeInfo] = []
-    for shade in shades:
-        ble_name = shade.get("bleName", "")
-        if not ble_name:
-            continue
-        name_b64 = shade.get("name", "")
-        try:
-            name = base64.b64decode(name_b64).decode("utf-8") if name_b64 else ble_name
-        except Exception:  # noqa: BLE001
-            name = ble_name
-        hub_shades.append(HubShadeInfo(name=name, ble_name=ble_name))
+    session = async_get_clientsession(hass)
+    timeout = aiohttp.ClientTimeout(total=10)
 
     # GetShadeKey BLE request: sid=251, cid=18, seqId=1, data_len=0
     request_frame = struct.pack("<BBBB", 251, 18, 1, 0)
 
     # Try each shade until one returns a valid key (some may be out of range)
     last_error: Exception = ValueError("No shades responded")
-    for shade in shades:
-        ble_name = shade.get("bleName", "")
-        if not ble_name:
-            continue
+    for hs in hub_shades:
         try:
             async with session.post(
-                f"{hub_url}/home/shades/exec?shades={ble_name}",
+                f"{hub_url}/home/shades/exec?shades={hs.ble_name}",
                 json={"hex": request_frame.hex()},
                 timeout=timeout,
             ) as resp:
@@ -126,6 +138,36 @@ async def _fetch_key_and_shades_from_hub(
     raise ValueError(f"No reachable shade returned a valid key: {last_error}")
 
 
+_HOMEKEY_SCHEMA = vol.Schema(
+    {
+        vol.Required("key_method", default="hub"): SelectSelector(
+            SelectSelectorConfig(
+                options=[
+                    {
+                        "value": "hub",
+                        "label": "Fetch automatically from PowerView hub",
+                    },
+                    {
+                        "value": "manual",
+                        "label": "Enter key manually (32 hex characters)",
+                    },
+                    {
+                        "value": "skip",
+                        "label": "Skip (no key — controls disabled for encrypted shades)",
+                    },
+                ]
+            )
+        ),
+        vol.Optional("hub_url", default="http://powerview-g3.local"): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.URL)
+        ),
+        vol.Optional("home_key", default=""): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.TEXT)
+        ),
+    }
+)
+
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for BT Battery Management System."""
 
@@ -147,17 +189,71 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._manufacturer_data_hex: str = ""
         self._device_name: str = ""
         self._home_key: str = ""
+        self._hub_url: str = ""
         self._hub_shades: list[HubShadeInfo] = []
 
     def _create_entry(self) -> ConfigFlowResult:
         """Create the config entry with collected data."""
+        data: dict[str, str] = {
+            "manufacturer_data": self._manufacturer_data_hex,
+            CONF_HOME_KEY: self._home_key,
+        }
+        if self._hub_url:
+            data["hub_url"] = self._hub_url
         return self.async_create_entry(
             title=self._device_name,
-            data={
-                "manufacturer_data": self._manufacturer_data_hex,
-                CONF_HOME_KEY: self._home_key,
-            },
+            data=data,
         )
+
+    async def _validate_homekey_input(
+        self, user_input: dict[str, Any], errors: dict[str, str]
+    ) -> bool:
+        """Parse and validate homekey user_input, populating self state.
+
+        Returns True on success, False on validation error (errors dict is populated).
+        On skip, self._home_key is set to "".
+        """
+        method = user_input.get("key_method", "skip")
+
+        if method == "skip":
+            self._home_key = ""
+            return True
+
+        if method == "manual":
+            raw = user_input.get("home_key", "").strip()
+            if "\\x" in raw:
+                raw = raw.replace("\\x", "")
+            if len(raw) != 32:
+                errors["home_key"] = "invalid_key_length"
+                return False
+            try:
+                bytes.fromhex(raw)
+            except ValueError:
+                errors["home_key"] = "invalid_key_format"
+                return False
+            self._home_key = raw.lower()
+            return True
+
+        if method == "hub":
+            hub_url = user_input.get("hub_url", "").rstrip("/")
+            try:
+                key, hub_shades = await _fetch_key_and_shades_from_hub(
+                    self.hass, hub_url
+                )
+                self._home_key = key.hex()
+                self._hub_url = hub_url
+                self._hub_shades = hub_shades
+                return True
+            except aiohttp.ClientResponseError:
+                errors["hub_url"] = "hub_http_error"
+            except aiohttp.ClientConnectionError:
+                errors["hub_url"] = "hub_connection_error"
+            except (asyncio.TimeoutError, TimeoutError):
+                errors["hub_url"] = "hub_timeout"
+            except ValueError:
+                errors["hub_url"] = "hub_protocol_error"
+
+        return False
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
@@ -189,6 +285,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             # Unencrypted shades can skip the homekey step entirely
             if not _needs_encryption(self._manufacturer_data_hex):
+                await self._resolve_friendly_name()
                 return self._create_entry()
 
             return await self.async_step_homekey_bluetooth()
@@ -208,95 +305,52 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         existing = self._existing_home_key()
         if existing and user_input is None:
             self._home_key = existing
+            await self._resolve_friendly_name()
             return self._create_entry()
 
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            method = user_input.get("key_method", "skip")
-
-            if method == "skip":
-                self._home_key = ""
+            if await self._validate_homekey_input(user_input, errors):
+                # Use hub name for the entry title if available
+                friendly = self._hub_name_for(self._device_name)
+                if friendly:
+                    self._device_name = friendly
                 return self._create_entry()
-
-            elif method == "manual":
-                raw = user_input.get("home_key", "").strip()
-                if "\\x" in raw:
-                    raw = raw.replace("\\x", "")
-                if len(raw) != 32:
-                    errors["home_key"] = "invalid_key_length"
-                else:
-                    try:
-                        bytes.fromhex(raw)
-                    except ValueError:
-                        errors["home_key"] = "invalid_key_format"
-                    else:
-                        self._home_key = raw.lower()
-                        return self._create_entry()
-
-            elif method == "hub":
-                hub_url = user_input.get("hub_url", "").rstrip("/")
-                try:
-                    key, hub_shades = await _fetch_key_and_shades_from_hub(
-                        self.hass, hub_url
-                    )
-                    self._home_key = key.hex()
-                    # Use hub name for the entry title if available
-                    for hs in hub_shades:
-                        if hs.ble_name == self._device_name:
-                            self._device_name = hs.name
-                            break
-                    return self._create_entry()
-                except aiohttp.ClientResponseError:
-                    errors["hub_url"] = "hub_http_error"
-                except aiohttp.ClientConnectionError:
-                    errors["hub_url"] = "hub_connection_error"
-                except (asyncio.TimeoutError, TimeoutError):
-                    errors["hub_url"] = "hub_timeout"
-                except ValueError:
-                    errors["hub_url"] = "hub_protocol_error"
 
         return self.async_show_form(
             step_id="homekey_bluetooth",
-            data_schema=vol.Schema(
-                {
-                    vol.Required("key_method", default="hub"): SelectSelector(
-                        SelectSelectorConfig(
-                            options=[
-                                {
-                                    "value": "hub",
-                                    "label": "Fetch automatically from PowerView hub",
-                                },
-                                {
-                                    "value": "manual",
-                                    "label": "Enter key manually (32 hex characters)",
-                                },
-                                {
-                                    "value": "skip",
-                                    "label": "Skip (no key — controls disabled for encrypted shades)",
-                                },
-                            ]
-                        )
-                    ),
-                    vol.Optional("hub_url", default="http://powerview-g3.local"): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.URL)
-                    ),
-                    vol.Optional("home_key", default=""): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.TEXT)
-                    ),
-                }
-            ),
+            data_schema=_HOMEKEY_SCHEMA,
             errors=errors,
             description_placeholders={"name": self._device_name},
         )
 
+    def _existing_entry_value(self, key: str) -> str:
+        """Return the first non-empty value for *key* across configured entries."""
+        for entry in self._async_current_entries():
+            if value := entry.data.get(key, ""):
+                return value
+        return ""
+
     def _existing_home_key(self) -> str:
         """Return the home_key from any already-configured entry, or ''."""
-        for entry in self._async_current_entries():
-            key = entry.data.get(CONF_HOME_KEY, "")
-            if key:
-                return key
-        return ""
+        return self._existing_entry_value(CONF_HOME_KEY)
+
+    async def _resolve_friendly_name(self) -> None:
+        """Try to resolve BLE device name to hub friendly name."""
+        hub_url = self._hub_url or self._existing_entry_value("hub_url")
+        if not hub_url:
+            return
+        try:
+            shades = await _fetch_shades_from_hub(self.hass, hub_url)
+            for hs in shades:
+                if hs.ble_name == self._device_name:
+                    self._device_name = hs.name
+                    break
+            if not self._hub_url:
+                self._hub_url = hub_url
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
+            pass
 
     def _hub_name_for(self, ble_name: str) -> str | None:
         """Return the human-readable hub name for a BLE name, or None."""
@@ -334,24 +388,29 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ble_name = device.name
                 name = self._hub_name_for(ble_name) or ble_name
                 mfct_hex = device.discovery_info.manufacturer_data[MFCT_ID].hex()
+                entry_data: dict[str, str] = {
+                    "manufacturer_data": mfct_hex,
+                    CONF_HOME_KEY: self._home_key,
+                }
+                if self._hub_url:
+                    entry_data["hub_url"] = self._hub_url
                 entries.append(
                     {
                         "address": address,
                         "name": name,
-                        "data": {
-                            "manufacturer_data": mfct_hex,
-                            CONF_HOME_KEY: self._home_key,
-                        },
+                        "data": entry_data,
                     }
                 )
 
             # Kick off auto-add flows for all but the last shade
-            for info in entries[:-1]:
-                await self.hass.config_entries.flow.async_init(
+            await asyncio.gather(*(
+                self.hass.config_entries.flow.async_init(
                     DOMAIN,
                     context={"source": "auto_add"},
                     data=info,
                 )
+                for info in entries[:-1]
+            ))
 
             # Create the final entry normally (ends this flow)
             last = entries[-1]
@@ -399,12 +458,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_auto_add(
-        self, data: dict[str, Any]
+        self, user_input: dict[str, Any]
     ) -> ConfigFlowResult:
         """Create a config entry for a shade selected via multi-select."""
-        await self.async_set_unique_id(data["address"])
+        await self.async_set_unique_id(user_input["address"])
         self._abort_if_unique_id_configured()
-        return self.async_create_entry(title=data["name"], data=data["data"])
+        return self.async_create_entry(
+            title=user_input["name"], data=user_input["data"]
+        )
 
     async def async_step_manual(
         self, user_input: dict[str, Any] | None = None
@@ -440,75 +501,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            method = user_input.get("key_method", "skip")
-
-            if method == "skip":
-                self._home_key = ""
+            if await self._validate_homekey_input(user_input, errors):
                 return await self.async_step_select_device()
-
-            elif method == "manual":
-                raw = user_input.get("home_key", "").strip()
-                # Accept \xNN\xNN... format (e.g. from ESP32 emulator serial log)
-                if "\\x" in raw:
-                    raw = raw.replace("\\x", "")
-                if len(raw) != 32:
-                    errors["home_key"] = "invalid_key_length"
-                else:
-                    try:
-                        bytes.fromhex(raw)
-                    except ValueError:
-                        errors["home_key"] = "invalid_key_format"
-                    else:
-                        self._home_key = raw.lower()
-                        return await self.async_step_select_device()
-
-            elif method == "hub":
-                hub_url = user_input.get("hub_url", "").rstrip("/")
-                try:
-                    key, hub_shades = await _fetch_key_and_shades_from_hub(
-                        self.hass, hub_url
-                    )
-                    self._home_key = key.hex()
-                    self._hub_shades = hub_shades
-                    return await self.async_step_select_device()
-                except aiohttp.ClientResponseError:
-                    errors["hub_url"] = "hub_http_error"
-                except aiohttp.ClientConnectionError:
-                    errors["hub_url"] = "hub_connection_error"
-                except (asyncio.TimeoutError, TimeoutError):
-                    errors["hub_url"] = "hub_timeout"
-                except ValueError:
-                    errors["hub_url"] = "hub_protocol_error"
 
         return self.async_show_form(
             step_id="homekey",
-            data_schema=vol.Schema(
-                {
-                    vol.Required("key_method", default="hub"): SelectSelector(
-                        SelectSelectorConfig(
-                            options=[
-                                {
-                                    "value": "hub",
-                                    "label": "Fetch automatically from PowerView hub",
-                                },
-                                {
-                                    "value": "manual",
-                                    "label": "Enter key manually (32 hex characters)",
-                                },
-                                {
-                                    "value": "skip",
-                                    "label": "Skip (no key — controls disabled for encrypted shades)",
-                                },
-                            ]
-                        )
-                    ),
-                    vol.Optional("hub_url", default="http://powerview-g3.local"): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.URL)
-                    ),
-                    vol.Optional("home_key", default=""): TextSelector(
-                        TextSelectorConfig(type=TextSelectorType.TEXT)
-                    ),
-                }
-            ),
+            data_schema=_HOMEKEY_SCHEMA,
             errors=errors,
         )

--- a/custom_components/hunterdouglas_powerview_ble/config_flow.py
+++ b/custom_components/hunterdouglas_powerview_ble/config_flow.py
@@ -69,9 +69,7 @@ def _parse_key_response(ble_name: str, result: dict) -> bytes | None:  # noqa: P
         )
         return None
     if response_bytes[4] != 0:
-        LOGGER.warning(
-            "Shade %s returned error status %d", ble_name, response_bytes[4]
-        )
+        LOGGER.warning("Shade %s returned error status %d", ble_name, response_bytes[4])
         return None
     key_data = response_bytes[5:]
     if len(key_data) != 16:
@@ -84,9 +82,7 @@ def _parse_key_response(ble_name: str, result: dict) -> bytes | None:  # noqa: P
     return key_data
 
 
-async def _fetch_key_from_hub(
-    hass: HomeAssistant, hub_url: str
-) -> bytes:
+async def _fetch_key_from_hub(hass: HomeAssistant, hub_url: str) -> bytes:
     """Fetch 16-byte homekey from a PowerView G3 hub.
 
     Tries each shade on the hub until one returns a valid key.
@@ -226,6 +222,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return True
 
         if method == "manual":
+            # Still capture a hub URL if the user provided one — the integration
+            # uses it to fetch shade metadata (friendly names, power_type) even
+            # when the homekey itself was supplied manually.
+            hub_url = user_input.get(CONF_HUB_URL, "").rstrip("/")
+            if hub_url:
+                self._hub_url = hub_url
             return self._validate_manual_key(user_input, errors)
 
         if method != "hub":
@@ -260,9 +262,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # the same network share the same home_id, so HA deduplicates every
         # subsequent shade discovery into this single flow via
         # "already_in_progress" rather than spawning one notification per shade.
-        mfr_data = bytearray(
-            discovery_info.manufacturer_data.get(MFCT_ID, b"")
-        )
+        mfr_data = bytearray(discovery_info.manufacturer_data.get(MFCT_ID, b""))
         if len(mfr_data) >= 2:
             home_id = int.from_bytes(mfr_data[0:2], byteorder="little")
             unique_id = f"pvhome_{home_id}"
@@ -310,4 +310,3 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "hub_url_example": "http://powerview-g3.local",
             },
         )
-

--- a/custom_components/hunterdouglas_powerview_ble/const.py
+++ b/custom_components/hunterdouglas_powerview_ble/const.py
@@ -9,6 +9,10 @@ MFCT_ID: Final[int] = 2073
 TIMEOUT: Final[int] = 5
 
 CONF_HOME_KEY: Final[str] = "home_key"
+CONF_HUB_URL: Final[str] = "hub_url"
+
+# dispatcher signal for newly discovered shades (format with entry_id)
+SIGNAL_NEW_SHADE: Final[str] = f"{DOMAIN}_new_shade_{{entry_id}}"
 
 # attributes (do not change)
 ATTR_RSSI: Final[str] = "rssi"

--- a/custom_components/hunterdouglas_powerview_ble/const.py
+++ b/custom_components/hunterdouglas_powerview_ble/const.py
@@ -8,10 +8,7 @@ LOGGER: Final = logging.getLogger(__package__)
 MFCT_ID: Final[int] = 2073
 TIMEOUT: Final[int] = 5
 
-# put the key here, needs to be 16 bytes long, e.g.
-# HOME_KEY: Final[bytes] = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f"
-HOME_KEY: Final[bytes] = b""
-
+CONF_HOME_KEY: Final[str] = "home_key"
 
 # attributes (do not change)
 ATTR_RSSI: Final[str] = "rssi"

--- a/custom_components/hunterdouglas_powerview_ble/const.py
+++ b/custom_components/hunterdouglas_powerview_ble/const.py
@@ -1,5 +1,6 @@
 """Constants for the BLE Battery Management System integration."""
 
+from enum import IntEnum
 import logging
 from typing import Final
 
@@ -10,6 +11,16 @@ TIMEOUT: Final[int] = 5
 
 CONF_HOME_KEY: Final[str] = "home_key"
 CONF_HUB_URL: Final[str] = "hub_url"
+CONF_POWER_TYPES: Final[str] = "power_types"
+
+
+class PowerType(IntEnum):
+    """Shade power source. Values match the BLE 0xFFDE reply's byte 0."""
+
+    HARDWIRED = 0
+    BATTERY = 1
+    RECHARGEABLE = 2
+
 
 # dispatcher signal for newly discovered shades (format with entry_id)
 SIGNAL_NEW_SHADE: Final[str] = f"{DOMAIN}_new_shade_{{entry_id}}"

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -28,7 +28,6 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
     ) -> None:
         """Initialize BMS data coordinator."""
         assert ble_device.name is not None
-        self._mac = ble_device.address
         self._friendly_name = friendly_name or ble_device.name
         home_key_hex: str = data.get(CONF_HOME_KEY, "")
         home_key: bytes = (
@@ -99,7 +98,7 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
     @property
     def device_present(self) -> bool:
         """Check if a device is present."""
-        return bluetooth.async_address_present(self.hass, self._mac, connectable=True)
+        return bluetooth.async_address_present(self.hass, self.address, connectable=True)
 
     def _async_stop(self) -> None:
         """Shutdown coordinator and any connection."""
@@ -117,14 +116,17 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
 
         LOGGER.debug("BLE event %s: %s", change, service_info.manufacturer_data)
         self.api.set_ble_device(service_info.device)
-        self.data = {ATTR_RSSI: service_info.rssi}
+        new_data: dict[str, int | float | bool] = {ATTR_RSSI: service_info.rssi}
         if change == bluetooth.BluetoothChange.ADVERTISEMENT:
-            self.data.update(
+            new_data.update(
                 self.api.dec_manufacturer_data(
                     bytearray(service_info.manufacturer_data.get(2073, b""))
                 )
             )
-            self.api.encrypted = bool(self.data.get("home_id"))
+            self.api.encrypted = bool(new_data.get("home_id"))
 
+        if new_data == self.data:
+            return
+        self.data = new_data
         LOGGER.debug("data sample %s", self.data)
         super()._async_handle_bluetooth_event(service_info, change)

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 
 from .api import SHADE_TYPE, PowerViewBLE
-from .const import ATTR_RSSI, DOMAIN, HOME_KEY, LOGGER
+from .const import ATTR_RSSI, CONF_HOME_KEY, DOMAIN, LOGGER
 
 
 class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
@@ -25,7 +25,9 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         """Initialize BMS data coordinator."""
         assert ble_device.name is not None
         self._mac = ble_device.address
-        self.api = PowerViewBLE(ble_device, HOME_KEY)
+        home_key_hex: str = data.get(CONF_HOME_KEY, "")
+        home_key: bytes = bytes.fromhex(home_key_hex) if len(home_key_hex) == 32 else b""
+        self.api = PowerViewBLE(ble_device, home_key)
         self.data: dict[str, int | float | bool] = {}
         self._manuf_dat = data.get("manufacturer_data")
         self.dev_details: dict[str, str] = {}

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -54,10 +54,11 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
 
     @property
     def type_id(self) -> int | None:
-        """Return the shade type ID from manufacturer data."""
+        """Return the shade type ID from manufacturer data or live BLE data."""
         if self._manuf_dat:
             return int(bytes.fromhex(self._manuf_dat)[2])
-        return None
+        live = self.data.get("type_id")
+        return int(live) if live is not None else None
 
     @property
     def shade_capabilities(self) -> ShadeCapability:

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.components.bluetooth.passive_update_coordinator import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 
-from .api import SHADE_TYPE, PowerViewBLE
+from .api import SHADE_TYPE, ShadeCapability, PowerViewBLE, get_shade_capabilities
 from .const import ATTR_RSSI, CONF_HOME_KEY, DOMAIN, LOGGER
 
 
@@ -38,6 +38,7 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         self.data: dict[str, int | float | bool] = {}
         self._manuf_dat = data.get("manufacturer_data")
         self.dev_details: dict[str, str] = {}
+        self.velocity: int = 0
 
         LOGGER.debug(
             "Initializing coordinator for %s (%s)",
@@ -50,6 +51,18 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
             ble_device.address,
             bluetooth.BluetoothScanningMode.ACTIVE,
         )
+
+    @property
+    def type_id(self) -> int | None:
+        """Return the shade type ID from manufacturer data."""
+        if self._manuf_dat:
+            return int(bytes.fromhex(self._manuf_dat)[2])
+        return None
+
+    @property
+    def shade_capabilities(self) -> ShadeCapability:
+        """Return the shade capabilities based on type ID."""
+        return get_shade_capabilities(self.type_id)
 
     async def query_dev_info(self) -> None:
         """Receive detailed information from device."""
@@ -70,12 +83,12 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
             configuration_url=None,
             manufacturer="Hunter Douglas",
             model=(
-                str(SHADE_TYPE.get(int(bytes.fromhex(self._manuf_dat)[2]), "unknown"))
-                if self._manuf_dat
+                str(SHADE_TYPE.get(self.type_id, "unknown"))
+                if self.type_id is not None
                 else None
             ),
             model_id=(
-                str(bytes.fromhex(self._manuf_dat)[2]) if self._manuf_dat else None
+                str(self.type_id) if self.type_id is not None else None
             ),
             serial_number=self.dev_details.get("serial_nr"),
             sw_version=self.dev_details.get("sw_rev"),

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.components.bluetooth.passive_update_coordinator import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 
-from .api import SHADE_TYPE, ShadeCapability, PowerViewBLE, get_shade_capabilities
+from .api import SHADE_TYPE, PowerViewBLE, ShadeCapability, get_shade_capabilities
 from .const import ATTR_RSSI, CONF_HOME_KEY, DOMAIN, LOGGER
 
 

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -20,7 +20,10 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
     """Update coordinator for a battery management system."""
 
     def __init__(
-        self, hass: HomeAssistant, ble_device: BLEDevice, data: dict[str, Any],
+        self,
+        hass: HomeAssistant,
+        ble_device: BLEDevice,
+        data: dict[str, Any],
         friendly_name: str | None = None,
     ) -> None:
         """Initialize BMS data coordinator."""
@@ -28,7 +31,9 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         self._mac = ble_device.address
         self._friendly_name = friendly_name or ble_device.name
         home_key_hex: str = data.get(CONF_HOME_KEY, "")
-        home_key: bytes = bytes.fromhex(home_key_hex) if len(home_key_hex) == 32 else b""
+        home_key: bytes = (
+            bytes.fromhex(home_key_hex) if len(home_key_hex) == 32 else b""
+        )
         self.api = PowerViewBLE(ble_device, home_key)
         self.data: dict[str, int | float | bool] = {}
         self._manuf_dat = data.get("manufacturer_data")

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -99,6 +99,7 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         #     self.hass.async_create_task(self._get_device_info())
 
         LOGGER.debug("BLE event %s: %s", change, service_info.manufacturer_data)
+        self.api.set_ble_device(service_info.device)
         self.data = {ATTR_RSSI: service_info.rssi}
         if change == bluetooth.BluetoothChange.ADVERTISEMENT:
             self.data.update(

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -20,11 +20,13 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
     """Update coordinator for a battery management system."""
 
     def __init__(
-        self, hass: HomeAssistant, ble_device: BLEDevice, data: dict[str, Any]
+        self, hass: HomeAssistant, ble_device: BLEDevice, data: dict[str, Any],
+        friendly_name: str | None = None,
     ) -> None:
         """Initialize BMS data coordinator."""
         assert ble_device.name is not None
         self._mac = ble_device.address
+        self._friendly_name = friendly_name or ble_device.name
         home_key_hex: str = data.get(CONF_HOME_KEY, "")
         home_key: bytes = bytes.fromhex(home_key_hex) if len(home_key_hex) == 32 else b""
         self.api = PowerViewBLE(ble_device, home_key)
@@ -34,7 +36,7 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
 
         LOGGER.debug(
             "Initializing coordinator for %s (%s)",
-            ble_device.name,
+            self._friendly_name,
             ble_device.address,
         )
         super().__init__(
@@ -52,16 +54,15 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
     @property
     def device_info(self) -> DeviceInfo:
         """Return detailed device information for GUI."""
-        LOGGER.debug("%s: device_info, %s", self.name, self.dev_details)
+        LOGGER.debug("%s: device_info, %s", self._friendly_name, self.dev_details)
         return DeviceInfo(
             identifiers={
-                (DOMAIN, self.name),
+                (DOMAIN, self.address),
                 (BLUETOOTH_DOMAIN, self.address),
             },
             connections={(CONNECTION_BLUETOOTH, self.address)},
-            name=self.name,
+            name=self._friendly_name,
             configuration_url=None,
-            # properties used in GUI:
             manufacturer="Hunter Douglas",
             model=(
                 str(SHADE_TYPE.get(int(bytes.fromhex(self._manuf_dat)[2]), "unknown"))
@@ -94,9 +95,6 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         change: bluetooth.BluetoothChange,
     ) -> None:
         """Handle a Bluetooth event."""
-
-        # if not self.dev_details:
-        #     self.hass.async_create_task(self._get_device_info())
 
         LOGGER.debug("BLE event %s: %s", change, service_info.manufacturer_data)
         self.api.set_ble_device(service_info.device)

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -1,8 +1,11 @@
 """Home Assistant coordinator for Hunter Douglas PowerView (BLE) integration."""
 
-from typing import Any
+import asyncio
+import time
+from typing import Any, Final
 
 from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
 
 from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth.const import DOMAIN as BLUETOOTH_DOMAIN
@@ -10,6 +13,7 @@ from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothDataUpdateCoordinator,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 
 from .api import SHADE_TYPE, PowerViewBLE, ShadeCapability, get_shade_capabilities
@@ -18,6 +22,11 @@ from .const import ATTR_RSSI, CONF_HOME_KEY, DOMAIN, LOGGER, PowerType
 
 class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
     """Update coordinator for a battery management system."""
+
+    # Firmware isn't in the advert — pull it via GATT. Retry every minute
+    # while empty, then re-check daily so firmware upgrades eventually surface.
+    _DEV_INFO_REFRESH_S: Final[float] = 24 * 3600
+    _DEV_INFO_RETRY_S: Final[float] = 60
 
     def __init__(
         self,
@@ -40,6 +49,8 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         self.dev_details: dict[str, str] = {}
         self.velocity: int = 0
         self._power_type: PowerType | None = power_type
+        self._last_dev_info_at: float = 0.0
+        self._dev_info_task: asyncio.Task[None] | None = None
 
         LOGGER.debug(
             "Initializing coordinator for %s (%s)",
@@ -67,9 +78,50 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         return get_shade_capabilities(self.type_id)
 
     async def query_dev_info(self) -> None:
-        """Receive detailed information from device."""
+        """Fetch device info over GATT and push into the device registry.
+
+        The HA device registry does not re-read DeviceInfo when the underlying
+        data changes, so we update it explicitly when new details arrive.
+        """
         LOGGER.debug("%s: querying device info", self.name)
-        self.dev_details.update(await self.api.query_dev_info())
+        self._last_dev_info_at = time.monotonic()
+        new = await self.api.query_dev_info()
+        if new and new != self.dev_details:
+            self.dev_details.update(new)
+            self._push_device_registry_update()
+
+    def _push_device_registry_update(self) -> None:
+        reg = dr.async_get(self.hass)
+        device = reg.async_get_device(identifiers={(DOMAIN, self.address)})
+        if device is None:
+            return
+        reg.async_update_device(
+            device.id,
+            sw_version=self.dev_details.get("sw_rev"),
+            hw_version=self.dev_details.get("hw_rev"),
+            serial_number=self.dev_details.get("serial_nr"),
+        )
+
+    async def _refresh_dev_info_safe(self) -> None:
+        try:
+            await self.query_dev_info()
+        except (BleakError, TimeoutError) as ex:
+            LOGGER.debug("%s: dev_info refresh failed: %s", self.name, ex)
+
+    def _maybe_refresh_dev_info(self) -> None:
+        """Schedule a background dev_info refresh if stale."""
+        if self._dev_info_task is not None and not self._dev_info_task.done():
+            return
+        interval = (
+            self._DEV_INFO_REFRESH_S
+            if self.dev_details.get("sw_rev")
+            else self._DEV_INFO_RETRY_S
+        )
+        if time.monotonic() - self._last_dev_info_at < interval:
+            return
+        self._dev_info_task = self.hass.async_create_background_task(
+            self._refresh_dev_info_safe(), name=f"pvble_dev_info_{self.address}"
+        )
 
     @property
     def power_type(self) -> PowerType | None:
@@ -124,6 +176,8 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
     def _async_stop(self) -> None:
         """Shutdown coordinator and any connection."""
         LOGGER.debug("%s: shutting down BMS device", self.name)
+        if self._dev_info_task is not None and not self._dev_info_task.done():
+            self._dev_info_task.cancel()
         self.hass.async_create_task(self.api.disconnect())
         super()._async_stop()
 
@@ -145,6 +199,7 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
                 )
             )
             self.api.encrypted = bool(new_data.get("home_id"))
+            self._maybe_refresh_dev_info()
 
         if new_data == self.data:
             return

--- a/custom_components/hunterdouglas_powerview_ble/coordinator.py
+++ b/custom_components/hunterdouglas_powerview_ble/coordinator.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 
 from .api import SHADE_TYPE, PowerViewBLE, ShadeCapability, get_shade_capabilities
-from .const import ATTR_RSSI, CONF_HOME_KEY, DOMAIN, LOGGER
+from .const import ATTR_RSSI, CONF_HOME_KEY, DOMAIN, LOGGER, PowerType
 
 
 class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
@@ -25,6 +25,7 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         ble_device: BLEDevice,
         data: dict[str, Any],
         friendly_name: str | None = None,
+        power_type: PowerType | None = None,
     ) -> None:
         """Initialize BMS data coordinator."""
         assert ble_device.name is not None
@@ -38,6 +39,7 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         self._manuf_dat = data.get("manufacturer_data")
         self.dev_details: dict[str, str] = {}
         self.velocity: int = 0
+        self._power_type: PowerType | None = power_type
 
         LOGGER.debug(
             "Initializing coordinator for %s (%s)",
@@ -70,6 +72,25 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
         self.dev_details.update(await self.api.query_dev_info())
 
     @property
+    def power_type(self) -> PowerType | None:
+        """Return the shade's power source, or None if unknown."""
+        return self._power_type
+
+    @property
+    def show_battery_entities(self) -> bool:
+        """Whether battery-related entities should be created for this shade.
+
+        Unknown power_type is treated as battery-ish so real battery data is
+        never silently hidden on unclassified shades.
+        """
+        return self._power_type != PowerType.HARDWIRED
+
+    async def query_power_type(self) -> None:
+        """Query the shade's power_type over BLE and cache the result."""
+        LOGGER.debug("%s: querying power_type", self.name)
+        self._power_type = await self.api.query_power_type()
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return detailed device information for GUI."""
         LOGGER.debug("%s: device_info, %s", self._friendly_name, self.dev_details)
@@ -87,9 +108,7 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
                 if self.type_id is not None
                 else None
             ),
-            model_id=(
-                str(self.type_id) if self.type_id is not None else None
-            ),
+            model_id=(str(self.type_id) if self.type_id is not None else None),
             serial_number=self.dev_details.get("serial_nr"),
             sw_version=self.dev_details.get("sw_rev"),
             hw_version=self.dev_details.get("hw_rev"),
@@ -98,7 +117,9 @@ class PVCoordinator(PassiveBluetoothDataUpdateCoordinator):
     @property
     def device_present(self) -> bool:
         """Check if a device is present."""
-        return bluetooth.async_address_present(self.hass, self.address, connectable=True)
+        return bluetooth.async_address_present(
+            self.hass, self.address, connectable=True
+        )
 
     def _async_stop(self) -> None:
         """Shutdown coordinator and any connection."""

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -62,7 +62,7 @@ class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEnti
     ) -> None:
         """Initialize the shade."""
         LOGGER.debug("%s: init() PowerViewCover", coordinator.name)
-        self._attr_name = CoverDeviceClass.SHADE
+        self._attr_name = None
         self._coord: PVCoordinator = coordinator
         self._attr_device_info = self._coord.device_info
         self._target_position: int | None = round(

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -36,6 +36,8 @@ def _add_entities(
         entities: list[PowerViewCover] = [PowerViewCoverTiltOnly(coordinator)]
     elif caps.has_tilt:
         entities = [PowerViewCoverTilt(coordinator)]
+    elif caps.is_top_down:
+        entities = [PowerViewCoverTopDown(coordinator)]
     else:
         entities = [PowerViewCover(coordinator)]
 
@@ -260,6 +262,72 @@ class PowerViewCoverTilt(PowerViewCover):
         LOGGER.debug("close cover tilt")
         _kwargs = {**kwargs, ATTR_TILT_POSITION: CLOSED_POSITION}
         await self.async_set_cover_tilt_position(**_kwargs)
+
+
+class PowerViewCoverTopDown(PowerViewCover):
+    """Representation of a top-down PowerView shade.
+
+    The device position axis is inverted: device 0 = open (fabric retracted),
+    device 100 = closed (fabric fully extended). We translate at the boundary
+    so HA's standard 0=closed / 100=open convention is preserved.
+    """
+
+    @property
+    def current_cover_position(self) -> int | None:  # type: ignore[reportIncompatibleVariableOverride]
+        """Return current position, inverting the device axis."""
+        pos: Final = self._coord.data.get(ATTR_CURRENT_POSITION)
+        return OPEN_POSITION - round(pos) if pos is not None else None
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move the cover to a specific position, inverting for the device."""
+        target_position: Final = kwargs.get(ATTR_POSITION)
+        if target_position is not None:
+            inverted = OPEN_POSITION - round(target_position)
+            LOGGER.debug("set top-down cover to position %f (device %i)", target_position, inverted)
+            if self.current_cover_position == round(target_position) and not (
+                self.is_closing or self.is_opening
+            ):
+                return
+            self._target_position = round(target_position)
+            try:
+                await self._coord.api.set_position(
+                    inverted,
+                    velocity=self._coord.velocity,
+                )
+                self.async_write_ha_state()
+            except BleakError as err:
+                LOGGER.error(
+                    "Failed to move cover '%s' to %f%%: %s",
+                    self.name,
+                    target_position,
+                    err,
+                )
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover (send device position 0)."""
+        LOGGER.debug("open top-down cover")
+        if self.current_cover_position == OPEN_POSITION:
+            return
+        try:
+            self._target_position = OPEN_POSITION
+            await self._coord.api.set_position(CLOSED_POSITION, velocity=self._coord.velocity)
+            self.async_write_ha_state()
+        except BleakError as err:
+            LOGGER.error("Failed to open cover '%s': %s", self.name, err)
+            self._reset_target_position()
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the cover (send device position 100)."""
+        LOGGER.debug("close top-down cover")
+        if self.current_cover_position == CLOSED_POSITION:
+            return
+        try:
+            self._target_position = CLOSED_POSITION
+            await self._coord.api.set_position(OPEN_POSITION, velocity=self._coord.velocity)
+            self.async_write_ha_state()
+        except BleakError as err:
+            LOGGER.error("Failed to close cover '%s': %s", self.name, err)
+            self._reset_target_position()
 
 
 class PowerViewCoverTiltOnly(PowerViewCoverTilt):

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -34,9 +34,9 @@ async def async_setup_entry(
     """Set up the demo cover platform."""
 
     coordinator: PVCoordinator = config_entry.runtime_data
-    model: Final[str|None] = coordinator.dev_details.get("model")
+    model: Final[str | None] = coordinator.dev_details.get("model")
     entities: list[PowerViewCover] = []
-    if model in ["39"]:
+    if model == "39":
         entities.append(PowerViewCoverTiltOnly(coordinator))
     else:
         entities.append(PowerViewCover(coordinator))

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -249,7 +249,7 @@ class PowerViewCoverTilt(PowerViewCover):
 
     async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self.async_stop_cover(kwargs=kwargs)
+        await self.async_stop_cover(**kwargs)
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -34,6 +34,8 @@ def _add_entities(
 
     if caps.tilt_only:
         entities: list[PowerViewCover] = [PowerViewCoverTiltOnly(coordinator)]
+    elif caps.is_tilt_on_closed:
+        entities = [PowerViewCoverTiltOnClosed(coordinator)]
     elif caps.has_tilt:
         entities = [PowerViewCoverTilt(coordinator)]
     elif caps.is_top_down:
@@ -260,6 +262,35 @@ class PowerViewCoverTilt(PowerViewCover):
         LOGGER.debug("close cover tilt")
         _kwargs = {**kwargs, ATTR_TILT_POSITION: CLOSED_POSITION}
         await self.async_set_cover_tilt_position(**_kwargs)
+
+
+class PowerViewCoverTiltOnClosed(PowerViewCoverTilt):
+    """Representation of a PowerView shade whose tilt is only available when closed.
+
+    Examples: Bottom Up 90° (type 18), Twist (type 44).
+
+    If a tilt command arrives while the shade is open, the shade is closed first
+    so the tilt mechanism is engaged before the command is sent.
+    """
+
+    def __init__(self, coordinator: PVCoordinator) -> None:
+        """Initialize the shade."""
+        LOGGER.debug("%s: init() PowerViewCoverTiltOnClosed", coordinator.name)
+        super().__init__(coordinator)
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Move the tilt to a specific position, closing first if needed."""
+        if self.current_cover_position != CLOSED_POSITION:
+            LOGGER.debug("tilt-on-closed: closing shade before tilting")
+            try:
+                self._target_position = CLOSED_POSITION
+                await self._coord.api.close(velocity=self._coord.velocity)
+                self.async_write_ha_state()
+            except BleakError as err:
+                LOGGER.error("Failed to close cover '%s' before tilt: %s", self.name, err)
+                self._reset_target_position()
+            return
+        await super().async_set_cover_tilt_position(**kwargs)
 
 
 class PowerViewCoverTopDown(PowerViewCover):

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -110,9 +110,7 @@ class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEnti
     @property
     def supported_features(self) -> CoverEntityFeature:  # type: ignore[reportIncompatibleVariableOverride]
         """Flag supported features, disable control if encryption is needed."""
-        if (
-            self._coord.data.get("home_id") and not self._coord.api.has_key
-        ) or self._coord.data.get("battery_charging"):
+        if self._coord.data.get("home_id") and not self._coord.api.has_key:
             return CoverEntityFeature(0)
 
         return super().supported_features

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -18,7 +18,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo, format_mac
+from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .api import CLOSED_POSITION, OPEN_POSITION
@@ -31,15 +31,17 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the demo cover platform."""
+    """Set up the cover platform."""
 
     coordinator: PVCoordinator = config_entry.runtime_data
-    model: Final[str | None] = coordinator.dev_details.get("model")
-    entities: list[PowerViewCover] = []
-    if model == "39":
-        entities.append(PowerViewCoverTiltOnly(coordinator))
+    caps = coordinator.shade_capabilities
+
+    if caps.tilt_only:
+        entities: list[PowerViewCover] = [PowerViewCoverTiltOnly(coordinator)]
+    elif caps.has_tilt:
+        entities = [PowerViewCoverTilt(coordinator)]
     else:
-        entities.append(PowerViewCover(coordinator))
+        entities = [PowerViewCover(coordinator)]
 
     async_add_entities(entities)
 
@@ -72,11 +74,6 @@ class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEnti
             f"{DOMAIN}_{format_mac(self._coord.address)}_{CoverDeviceClass.SHADE}"
         )
         super().__init__(coordinator)
-
-    @property
-    def device_info(self) -> DeviceInfo:  # type: ignore[reportIncompatibleVariableOverride]
-        """Return the device_info of the device."""
-        return self._coord.device_info
 
     @property
     def is_opening(self) -> bool | None:  # type: ignore[reportIncompatibleVariableOverride]
@@ -133,7 +130,10 @@ class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEnti
                 return
             self._target_position = round(target_position)
             try:
-                await self._coord.api.set_position(round(target_position))
+                await self._coord.api.set_position(
+                    round(target_position),
+                    velocity=self._coord.velocity,
+                )
                 self.async_write_ha_state()
             except BleakError as err:
                 LOGGER.error(
@@ -153,7 +153,7 @@ class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEnti
             return
         try:
             self._target_position = OPEN_POSITION
-            await self._coord.api.open()
+            await self._coord.api.open(velocity=self._coord.velocity)
             self.async_write_ha_state()
         except BleakError as err:
             LOGGER.error("Failed to open cover '%s': %s", self.name, err)
@@ -166,7 +166,7 @@ class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEnti
             return
         try:
             self._target_position = CLOSED_POSITION
-            await self._coord.api.close()
+            await self._coord.api.close(velocity=self._coord.velocity)
             self.async_write_ha_state()
         except BleakError as err:
             LOGGER.error("Failed to close cover '%s': %s", self.name, err)
@@ -227,7 +227,9 @@ class PowerViewCoverTilt(PowerViewCover):
 
             try:
                 await self._coord.api.set_position(
-                    self.current_cover_position, tilt=target_position
+                    self.current_cover_position,
+                    tilt=target_position,
+                    velocity=self._coord.velocity,
                 )
                 self.async_write_ha_state()
             except BleakError as err:

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.device_registry import DeviceInfo, format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .api import CLOSED_POSITION, OPEN_POSITION
-from .const import DOMAIN, HOME_KEY, LOGGER
+from .const import DOMAIN, LOGGER
 from .coordinator import PVCoordinator
 
 
@@ -107,7 +107,7 @@ class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEnti
     def supported_features(self) -> CoverEntityFeature:  # type: ignore[reportIncompatibleVariableOverride]
         """Flag supported features, disable control if encryption is needed."""
         if (
-            self._coord.data.get("home_id") and len(HOME_KEY) != 16
+            self._coord.data.get("home_id") and not self._coord.api.has_key
         ) or self._coord.data.get("battery_charging"):
             return CoverEntityFeature(0)
 

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -16,24 +16,20 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import ConfigEntryType, async_setup_shade_platform
 from .api import CLOSED_POSITION, OPEN_POSITION
 from .const import DOMAIN, LOGGER
 from .coordinator import PVCoordinator
 
 
-async def async_setup_entry(
-    _hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+def _add_entities(
+    coordinator: PVCoordinator, async_add_entities: AddEntitiesCallback
 ) -> None:
-    """Set up the cover platform."""
-
-    coordinator: PVCoordinator = config_entry.runtime_data
+    """Create cover entities for a single shade coordinator."""
     caps = coordinator.shade_capabilities
 
     if caps.tilt_only:
@@ -44,6 +40,15 @@ async def async_setup_entry(
         entities = [PowerViewCover(coordinator)]
 
     async_add_entities(entities)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntryType,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the cover platform."""
+    async_setup_shade_platform(hass, config_entry, async_add_entities, _add_entities)
 
 
 class PowerViewCover(PassiveBluetoothCoordinatorEntity[PVCoordinator], CoverEntity):  # type: ignore[reportIncompatibleVariableOverride]

--- a/custom_components/hunterdouglas_powerview_ble/cover.py
+++ b/custom_components/hunterdouglas_powerview_ble/cover.py
@@ -287,7 +287,9 @@ class PowerViewCoverTiltOnClosed(PowerViewCoverTilt):
                 await self._coord.api.close(velocity=self._coord.velocity)
                 self.async_write_ha_state()
             except BleakError as err:
-                LOGGER.error("Failed to close cover '%s' before tilt: %s", self.name, err)
+                LOGGER.error(
+                    "Failed to close cover '%s' before tilt: %s", self.name, err
+                )
                 self._reset_target_position()
             return
         await super().async_set_cover_tilt_position(**kwargs)
@@ -312,7 +314,11 @@ class PowerViewCoverTopDown(PowerViewCover):
         target_position: Final = kwargs.get(ATTR_POSITION)
         if target_position is not None:
             inverted = OPEN_POSITION - round(target_position)
-            LOGGER.debug("set top-down cover to position %f (device %i)", target_position, inverted)
+            LOGGER.debug(
+                "set top-down cover to position %f (device %i)",
+                target_position,
+                inverted,
+            )
             if self.current_cover_position == round(target_position) and not (
                 self.is_closing or self.is_opening
             ):
@@ -339,7 +345,9 @@ class PowerViewCoverTopDown(PowerViewCover):
             return
         try:
             self._target_position = OPEN_POSITION
-            await self._coord.api.set_position(CLOSED_POSITION, velocity=self._coord.velocity)
+            await self._coord.api.set_position(
+                CLOSED_POSITION, velocity=self._coord.velocity
+            )
             self.async_write_ha_state()
         except BleakError as err:
             LOGGER.error("Failed to open cover '%s': %s", self.name, err)
@@ -352,7 +360,9 @@ class PowerViewCoverTopDown(PowerViewCover):
             return
         try:
             self._target_position = CLOSED_POSITION
-            await self._coord.api.set_position(OPEN_POSITION, velocity=self._coord.velocity)
+            await self._coord.api.set_position(
+                OPEN_POSITION, velocity=self._coord.velocity
+            )
             self.async_write_ha_state()
         except BleakError as err:
             LOGGER.error("Failed to close cover '%s': %s", self.name, err)

--- a/custom_components/hunterdouglas_powerview_ble/manifest.json
+++ b/custom_components/hunterdouglas_powerview_ble/manifest.json
@@ -16,5 +16,5 @@
   "issue_tracker": "https://github.com/patman15/hdpv_ble/issues",
   "loggers": ["hunterdouglas_powerview_ble"],
   "requirements": ["cryptography>=43.0.0"],
-  "version": "0.23"
+  "version": "0.24"
 }

--- a/custom_components/hunterdouglas_powerview_ble/manifest.json
+++ b/custom_components/hunterdouglas_powerview_ble/manifest.json
@@ -11,7 +11,7 @@
   "config_flow": true,
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://github.com/patman15/hdpv_ble",
-  "integration_type": "device",
+  "integration_type": "hub",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/patman15/hdpv_ble/issues",
   "loggers": ["hunterdouglas_powerview_ble"],

--- a/custom_components/hunterdouglas_powerview_ble/number.py
+++ b/custom_components/hunterdouglas_powerview_ble/number.py
@@ -1,0 +1,69 @@
+"""Hunter Douglas PowerView velocity control."""
+
+from homeassistant.components.bluetooth.passive_update_coordinator import (
+    PassiveBluetoothCoordinatorEntity,
+)
+from homeassistant.components.number import NumberMode, RestoreNumber
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import ConfigEntryType
+from .const import DOMAIN, LOGGER
+from .coordinator import PVCoordinator
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    config_entry: ConfigEntryType,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the velocity number entity."""
+
+    coordinator: PVCoordinator = config_entry.runtime_data
+    async_add_entities([PowerViewVelocity(coordinator)])
+
+
+class PowerViewVelocity(
+    PassiveBluetoothCoordinatorEntity[PVCoordinator], RestoreNumber
+):  # type: ignore[reportIncompatibleVariableOverride]
+    """Number entity to control shade movement velocity."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Velocity"
+    _attr_icon = "mdi:speedometer"
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: PVCoordinator) -> None:
+        """Initialize the velocity entity."""
+        self._coord = coordinator
+        self._attr_device_info = self._coord.device_info
+        self._attr_unique_id = (
+            f"{DOMAIN}_{format_mac(self._coord.address)}_velocity"
+        )
+        super().__init__(coordinator)
+
+    @property
+    def native_value(self) -> int:
+        """Return the current velocity value."""
+        return self._coord.velocity
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known velocity on startup."""
+        await super().async_added_to_hass()
+        last_data = await self.async_get_last_number_data()
+        if last_data and last_data.native_value is not None:
+            self._coord.velocity = int(last_data.native_value)
+            LOGGER.debug(
+                "%s: restored velocity to %s", self._coord.name, self._coord.velocity
+            )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the velocity value."""
+        self._coord.velocity = int(value)
+        self.async_write_ha_state()

--- a/custom_components/hunterdouglas_powerview_ble/number.py
+++ b/custom_components/hunterdouglas_powerview_ble/number.py
@@ -9,20 +9,25 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ConfigEntryType
+from . import ConfigEntryType, async_setup_shade_platform
 from .const import DOMAIN, LOGGER
 from .coordinator import PVCoordinator
 
 
+def _add_entities(
+    coordinator: PVCoordinator, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Create velocity number entity for a single shade coordinator."""
+    async_add_entities([PowerViewVelocity(coordinator)])
+
+
 async def async_setup_entry(
-    _hass: HomeAssistant,
+    hass: HomeAssistant,
     config_entry: ConfigEntryType,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the velocity number entity."""
-
-    coordinator: PVCoordinator = config_entry.runtime_data
-    async_add_entities([PowerViewVelocity(coordinator)])
+    async_setup_shade_platform(hass, config_entry, async_add_entities, _add_entities)
 
 
 class PowerViewVelocity(

--- a/custom_components/hunterdouglas_powerview_ble/number.py
+++ b/custom_components/hunterdouglas_powerview_ble/number.py
@@ -48,9 +48,7 @@ class PowerViewVelocity(
         """Initialize the velocity entity."""
         self._coord = coordinator
         self._attr_device_info = self._coord.device_info
-        self._attr_unique_id = (
-            f"{DOMAIN}_{format_mac(self._coord.address)}_velocity"
-        )
+        self._attr_unique_id = f"{DOMAIN}_{format_mac(self._coord.address)}_velocity"
         super().__init__(coordinator)
 
     @property

--- a/custom_components/hunterdouglas_powerview_ble/sensor.py
+++ b/custom_components/hunterdouglas_powerview_ble/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import ConfigEntryType
+from . import ConfigEntryType, async_setup_shade_platform
 from .const import ATTR_RSSI, DOMAIN
 from .coordinator import PVCoordinator
 
@@ -39,18 +39,25 @@ SENSOR_TYPES: list[SensorEntityDescription] = [
 ]
 
 
+def _add_entities(
+    coordinator: PVCoordinator, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Create sensor entities for a single shade coordinator."""
+    async_add_entities(
+        [
+            PVSensor(coordinator, descr, format_mac(coordinator.address))
+            for descr in SENSOR_TYPES
+        ]
+    )
+
+
 async def async_setup_entry(
-    _hass: HomeAssistant,
+    hass: HomeAssistant,
     config_entry: ConfigEntryType,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add sensors for passed config_entry in Home Assistant."""
-
-    pv_dev: PVCoordinator = config_entry.runtime_data
-    for descr in SENSOR_TYPES:
-        async_add_entities(
-            [PVSensor(pv_dev, descr, format_mac(config_entry.unique_id))]
-        )
+    async_setup_shade_platform(hass, config_entry, async_add_entities, _add_entities)
 
 
 class PVSensor(PassiveBluetoothCoordinatorEntity[PVCoordinator], SensorEntity):  # type: ignore[reportIncompatibleMethodOverride]

--- a/custom_components/hunterdouglas_powerview_ble/sensor.py
+++ b/custom_components/hunterdouglas_powerview_ble/sensor.py
@@ -43,10 +43,12 @@ def _add_entities(
     coordinator: PVCoordinator, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Create sensor entities for a single shade coordinator."""
+    include_battery = coordinator.show_battery_entities
     async_add_entities(
         [
             PVSensor(coordinator, descr, format_mac(coordinator.address))
             for descr in SENSOR_TYPES
+            if include_battery or descr.key != ATTR_BATTERY_LEVEL
         ]
     )
 

--- a/custom_components/hunterdouglas_powerview_ble/strings.json
+++ b/custom_components/hunterdouglas_powerview_ble/strings.json
@@ -25,7 +25,7 @@
           "home_key": "HomeKey (32 hex characters or \\xNN format)"
         },
         "data_description": {
-          "hub_url": "Base URL of your PowerView G3 hub, e.g. http://powerview-g3.local",
+          "hub_url": "Base URL of your PowerView G3 hub, e.g. {hub_url_example}",
           "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
         }
       },
@@ -38,7 +38,7 @@
           "home_key": "HomeKey (32 hex characters or \\xNN format)"
         },
         "data_description": {
-          "hub_url": "Base URL of your PowerView G3 hub, e.g. http://powerview-g3.local",
+          "hub_url": "Base URL of your PowerView G3 hub, e.g. {hub_url_example}",
           "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
         }
       },

--- a/custom_components/hunterdouglas_powerview_ble/strings.json
+++ b/custom_components/hunterdouglas_powerview_ble/strings.json
@@ -1,24 +1,10 @@
 {
   "config": {
-    "flow_title": "Setup {name}",
+    "flow_title": "PowerView Home Setup",
     "step": {
       "user": {
-        "title": "Add PowerView Shade",
-        "menu_options": {
-          "select_device": "Select from discovered shades",
-          "manual": "Enter device details manually"
-        },
-        "menu_option_descriptions": {
-          "select_device": "Choose from shades detected via Bluetooth nearby.",
-          "manual": "Enter a Bluetooth MAC address and device name directly, for example if a shade is out of range of discovery."
-        }
-      },
-      "bluetooth_confirm": {
-        "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
-      },
-      "homekey": {
-        "title": "Configure HomeKey",
-        "description": "All shades on a PowerView network share the same encryption key. The recommended method is to fetch it from your G3 hub. You can also enter the key manually, or skip if your shades are unencrypted.",
+        "title": "Set up PowerView Home",
+        "description": "Configure your PowerView encryption key. All shades on your network will be discovered automatically via Bluetooth.",
         "data": {
           "key_method": "Key source",
           "hub_url": "PowerView hub URL",
@@ -27,37 +13,6 @@
         "data_description": {
           "hub_url": "Base URL of your PowerView G3 hub, e.g. {hub_url_example}",
           "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
-        }
-      },
-      "homekey_bluetooth": {
-        "title": "Configure HomeKey for {name}",
-        "description": "This shade uses encryption. The recommended method is to fetch the key from your G3 hub. You can also enter it manually, or skip (controls will be disabled until a key is configured).",
-        "data": {
-          "key_method": "Key source",
-          "hub_url": "PowerView hub URL",
-          "home_key": "HomeKey (32 hex characters or \\xNN format)"
-        },
-        "data_description": {
-          "hub_url": "Base URL of your PowerView G3 hub, e.g. {hub_url_example}",
-          "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
-        }
-      },
-      "auto_add_confirm": {
-        "description": "Do you want to set up {name}?"
-      },
-      "select_device": {
-        "title": "Select Shades",
-        "description": "Select the PowerView shades to add via Bluetooth.",
-        "data": {
-          "address": "Shades"
-        }
-      },
-      "manual": {
-        "title": "Enter Device Details",
-        "description": "Enter the device details manually.",
-        "data": {
-          "address": "Bluetooth MAC address (e.g. AA:BB:CC:DD:EE:FF)",
-          "ble_name": "BLE device name (e.g. DUE:94ED)"
         }
       }
     },
@@ -71,8 +26,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-      "not_supported": "Device not supported"
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   }
 }

--- a/custom_components/hunterdouglas_powerview_ble/strings.json
+++ b/custom_components/hunterdouglas_powerview_ble/strings.json
@@ -31,6 +31,9 @@
           "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
         }
       },
+      "auto_add_confirm": {
+        "description": "Do you want to set up {name}?"
+      },
       "select_device": {
         "title": "Select Shades",
         "description": "Select the PowerView shades to add via Bluetooth.",

--- a/custom_components/hunterdouglas_powerview_ble/strings.json
+++ b/custom_components/hunterdouglas_powerview_ble/strings.json
@@ -2,6 +2,17 @@
   "config": {
     "flow_title": "Setup {name}",
     "step": {
+      "user": {
+        "title": "Add PowerView Shade",
+        "menu_options": {
+          "select_device": "Select from discovered shades",
+          "manual": "Enter device details manually"
+        },
+        "menu_option_descriptions": {
+          "select_device": "Choose from shades detected via Bluetooth nearby.",
+          "manual": "Enter a Bluetooth MAC address and device name directly, for example if a shade is out of range of discovery."
+        }
+      },
       "bluetooth_confirm": {
         "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
       },
@@ -43,7 +54,7 @@
       },
       "manual": {
         "title": "Enter Device Details",
-        "description": "No PowerView shades were found via Bluetooth. Enter the device details manually.",
+        "description": "Enter the device details manually.",
         "data": {
           "address": "Bluetooth MAC address (e.g. AA:BB:CC:DD:EE:FF)",
           "ble_name": "BLE device name (e.g. DUE:94ED)"

--- a/custom_components/hunterdouglas_powerview_ble/strings.json
+++ b/custom_components/hunterdouglas_powerview_ble/strings.json
@@ -4,7 +4,56 @@
     "step": {
       "bluetooth_confirm": {
         "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]"
+      },
+      "homekey": {
+        "title": "Configure HomeKey",
+        "description": "All shades on a PowerView network share the same encryption key. The recommended method is to fetch it from your G3 hub. You can also enter the key manually, or skip if your shades are unencrypted.",
+        "data": {
+          "key_method": "Key source",
+          "hub_url": "PowerView hub URL",
+          "home_key": "HomeKey (32 hex characters or \\xNN format)"
+        },
+        "data_description": {
+          "hub_url": "Base URL of your PowerView G3 hub, e.g. http://powerview-g3.local",
+          "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
+        }
+      },
+      "homekey_bluetooth": {
+        "title": "Configure HomeKey for {name}",
+        "description": "This shade uses encryption. The recommended method is to fetch the key from your G3 hub. You can also enter it manually, or skip (controls will be disabled until a key is configured).",
+        "data": {
+          "key_method": "Key source",
+          "hub_url": "PowerView hub URL",
+          "home_key": "HomeKey (32 hex characters or \\xNN format)"
+        },
+        "data_description": {
+          "hub_url": "Base URL of your PowerView G3 hub, e.g. http://powerview-g3.local",
+          "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
+        }
+      },
+      "select_device": {
+        "title": "Select Shades",
+        "description": "Select the PowerView shades to add via Bluetooth.",
+        "data": {
+          "address": "Shades"
+        }
+      },
+      "manual": {
+        "title": "Enter Device Details",
+        "description": "No PowerView shades were found via Bluetooth. Enter the device details manually.",
+        "data": {
+          "address": "Bluetooth MAC address (e.g. AA:BB:CC:DD:EE:FF)",
+          "ble_name": "BLE device name (e.g. DUE:94ED)"
+        }
       }
+    },
+    "error": {
+      "invalid_key_format": "HomeKey must be a valid hexadecimal string",
+      "invalid_key_length": "HomeKey must be exactly 32 hex characters (16 bytes)",
+      "hub_connection_error": "Cannot connect to the PowerView hub",
+      "hub_http_error": "Hub returned an HTTP error",
+      "hub_timeout": "Connection to hub timed out",
+      "hub_protocol_error": "Hub returned an unexpected response"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/custom_components/hunterdouglas_powerview_ble/translations/en.json
+++ b/custom_components/hunterdouglas_powerview_ble/translations/en.json
@@ -2,6 +2,17 @@
     "config": {
         "flow_title": "Setup {name}",
         "step": {
+            "user": {
+                "title": "Add PowerView Shade",
+                "menu_options": {
+                    "select_device": "Select from discovered shades",
+                    "manual": "Enter device details manually"
+                },
+                "menu_option_descriptions": {
+                    "select_device": "Choose from shades detected via Bluetooth nearby.",
+                    "manual": "Enter a Bluetooth MAC address and device name directly, for example if a shade is out of range of discovery."
+                }
+            },
             "bluetooth_confirm": {
                 "description": "Do you want to set up {name}?"
             },
@@ -40,7 +51,7 @@
             },
             "manual": {
                 "title": "Enter Device Details",
-                "description": "No PowerView shades were found via Bluetooth. Enter the device details manually.",
+                "description": "Enter the device details manually.",
                 "data": {
                     "address": "Bluetooth MAC address (e.g. AA:BB:CC:DD:EE:FF)",
                     "ble_name": "BLE device name (e.g. DUE:94ED)"

--- a/custom_components/hunterdouglas_powerview_ble/translations/en.json
+++ b/custom_components/hunterdouglas_powerview_ble/translations/en.json
@@ -1,15 +1,64 @@
 {
     "config": {
-        "abort": {
-            "already_configured": "Device is already configured",
-            "no_devices_found": "No devices found on the network",
-            "not_supported": "Device not supported"
-        },
         "flow_title": "Setup {name}",
         "step": {
             "bluetooth_confirm": {
                 "description": "Do you want to set up {name}?"
+            },
+            "homekey": {
+                "title": "Configure HomeKey",
+                "description": "All shades on a PowerView network share the same encryption key. The recommended method is to fetch it from your G3 hub. You can also enter the key manually, or skip if your shades are unencrypted.",
+                "data": {
+                    "key_method": "Key source",
+                    "hub_url": "PowerView hub URL",
+                    "home_key": "HomeKey (32 hex characters or \\xNN format)"
+                },
+                "data_description": {
+                    "hub_url": "Base URL of your PowerView G3 hub, e.g. http://powerview-g3.local",
+                    "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
+                }
+            },
+            "homekey_bluetooth": {
+                "title": "Configure HomeKey for {name}",
+                "description": "This shade uses encryption. The recommended method is to fetch the key from your G3 hub. You can also enter it manually, or skip (controls will be disabled until a key is configured).",
+                "data": {
+                    "key_method": "Key source",
+                    "hub_url": "PowerView hub URL",
+                    "home_key": "HomeKey (32 hex characters or \\xNN format)"
+                },
+                "data_description": {
+                    "hub_url": "Base URL of your PowerView G3 hub, e.g. http://powerview-g3.local",
+                    "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
+                }
+            },
+            "select_device": {
+                "title": "Select Shades",
+                "description": "Select the PowerView shades to add via Bluetooth.",
+                "data": {
+                    "address": "Shades"
+                }
+            },
+            "manual": {
+                "title": "Enter Device Details",
+                "description": "No PowerView shades were found via Bluetooth. Enter the device details manually.",
+                "data": {
+                    "address": "Bluetooth MAC address (e.g. AA:BB:CC:DD:EE:FF)",
+                    "ble_name": "BLE device name (e.g. DUE:94ED)"
+                }
             }
+        },
+        "error": {
+            "invalid_key_format": "HomeKey must be a valid hexadecimal string",
+            "invalid_key_length": "HomeKey must be exactly 32 hex characters (16 bytes)",
+            "hub_connection_error": "Cannot connect to the PowerView hub",
+            "hub_http_error": "Hub returned an HTTP error",
+            "hub_timeout": "Connection to hub timed out",
+            "hub_protocol_error": "Hub returned an unexpected response"
+        },
+        "abort": {
+            "already_configured": "Device is already configured",
+            "no_devices_found": "No devices found on the network",
+            "not_supported": "Device not supported"
         }
     }
 }

--- a/custom_components/hunterdouglas_powerview_ble/translations/en.json
+++ b/custom_components/hunterdouglas_powerview_ble/translations/en.json
@@ -1,24 +1,10 @@
 {
     "config": {
-        "flow_title": "Setup {name}",
+        "flow_title": "PowerView Home Setup",
         "step": {
             "user": {
-                "title": "Add PowerView Shade",
-                "menu_options": {
-                    "select_device": "Select from discovered shades",
-                    "manual": "Enter device details manually"
-                },
-                "menu_option_descriptions": {
-                    "select_device": "Choose from shades detected via Bluetooth nearby.",
-                    "manual": "Enter a Bluetooth MAC address and device name directly, for example if a shade is out of range of discovery."
-                }
-            },
-            "bluetooth_confirm": {
-                "description": "Do you want to set up {name}?"
-            },
-            "homekey": {
-                "title": "Configure HomeKey",
-                "description": "All shades on a PowerView network share the same encryption key. The recommended method is to fetch it from your G3 hub. You can also enter the key manually, or skip if your shades are unencrypted.",
+                "title": "Set up PowerView Home",
+                "description": "Configure your PowerView encryption key. All shades on your network will be discovered automatically via Bluetooth.",
                 "data": {
                     "key_method": "Key source",
                     "hub_url": "PowerView hub URL",
@@ -27,34 +13,6 @@
                 "data_description": {
                     "hub_url": "Base URL of your PowerView G3 hub, e.g. {hub_url_example}",
                     "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
-                }
-            },
-            "homekey_bluetooth": {
-                "title": "Configure HomeKey for {name}",
-                "description": "This shade uses encryption. The recommended method is to fetch the key from your G3 hub. You can also enter it manually, or skip (controls will be disabled until a key is configured).",
-                "data": {
-                    "key_method": "Key source",
-                    "hub_url": "PowerView hub URL",
-                    "home_key": "HomeKey (32 hex characters or \\xNN format)"
-                },
-                "data_description": {
-                    "hub_url": "Base URL of your PowerView G3 hub, e.g. {hub_url_example}",
-                    "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
-                }
-            },
-            "select_device": {
-                "title": "Select Shades",
-                "description": "Select the PowerView shades to add via Bluetooth.",
-                "data": {
-                    "address": "Shades"
-                }
-            },
-            "manual": {
-                "title": "Enter Device Details",
-                "description": "Enter the device details manually.",
-                "data": {
-                    "address": "Bluetooth MAC address (e.g. AA:BB:CC:DD:EE:FF)",
-                    "ble_name": "BLE device name (e.g. DUE:94ED)"
                 }
             }
         },
@@ -68,8 +26,7 @@
         },
         "abort": {
             "already_configured": "Device is already configured",
-            "no_devices_found": "No devices found on the network",
-            "not_supported": "Device not supported"
+            "single_instance_allowed": "Already configured. Only a single configuration possible."
         }
     }
 }

--- a/custom_components/hunterdouglas_powerview_ble/translations/en.json
+++ b/custom_components/hunterdouglas_powerview_ble/translations/en.json
@@ -25,7 +25,7 @@
                     "home_key": "HomeKey (32 hex characters or \\xNN format)"
                 },
                 "data_description": {
-                    "hub_url": "Base URL of your PowerView G3 hub, e.g. http://powerview-g3.local",
+                    "hub_url": "Base URL of your PowerView G3 hub, e.g. {hub_url_example}",
                     "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
                 }
             },
@@ -38,7 +38,7 @@
                     "home_key": "HomeKey (32 hex characters or \\xNN format)"
                 },
                 "data_description": {
-                    "hub_url": "Base URL of your PowerView G3 hub, e.g. http://powerview-g3.local",
+                    "hub_url": "Base URL of your PowerView G3 hub, e.g. {hub_url_example}",
                     "home_key": "32-character hex string (e.g. 0102030405060708090a0b0c0d0e0f10) or \\x escaped format (e.g. \\x01\\x02...)"
                 }
             },

--- a/scripts/extract_gateway3_homekey.py
+++ b/scripts/extract_gateway3_homekey.py
@@ -61,7 +61,9 @@ def get_shade_key(hub: str, ble_name) -> bytes:
     response: Final[bytes] = bytes.fromhex(responses[0]["hex"])
     dec_resp: Final[dict[str, Any]] = decode_response(response)
     if dec_resp["errorCode"] != 0:
-        raise ValueError(f"BLE errorCode={dec_resp['errorCode']} data={dec_resp['data'].hex()}")
+        raise ValueError(
+            f"BLE errorCode={dec_resp['errorCode']} data={dec_resp['data'].hex()}"
+        )
     if len(dec_resp["data"]) != 16:
         raise ValueError("Expected 16 byte homekey")
     return dec_resp["data"]

--- a/scripts/extract_gateway3_homekey.py
+++ b/scripts/extract_gateway3_homekey.py
@@ -55,12 +55,13 @@ def get_shade_key(hub: str, ble_name) -> bytes:
         raise
 
     result: dict = json.loads(shades_exec_resp.content)
-    if result.get("err") != 0 or len(result.get("responses", [])) != 1:
-        raise OSError("Error when attempting GetShadeKey")
-    response: Final[bytes] = bytes.fromhex(result["responses"][0]["hex"])
+    responses = result.get("responses", [])
+    if len(responses) != 1 or "hex" not in responses[0]:
+        raise OSError(f"Error when attempting GetShadeKey: {result}")
+    response: Final[bytes] = bytes.fromhex(responses[0]["hex"])
     dec_resp: Final[dict[str, Any]] = decode_response(response)
     if dec_resp["errorCode"] != 0:
-        raise ValueError("BLE errorCode is not 0")
+        raise ValueError(f"BLE errorCode={dec_resp['errorCode']} data={dec_resp['data'].hex()}")
     if len(dec_resp["data"]) != 16:
         raise ValueError("Expected 16 byte homekey")
     return dec_resp["data"]
@@ -79,9 +80,23 @@ def main(hub: str) -> int:
 
     shades = json.loads(shades_resp.content)
     print(f"Found {len(shades)} shades, interrogating")
+    network_key: bytes | None = None
     for shade in shades:
         name: str = base64.b64decode(shade["name"]).decode("utf-8")
-        key: bytes = get_shade_key(hub, shade["bleName"])
+        try:
+            key: bytes = get_shade_key(hub, shade["bleName"])
+            network_key = key
+        except (OSError, ValueError) as ex:
+            if network_key is not None:
+                key = network_key
+                print(f"Shade '{name}':")
+                print(f"\tBLE name: '{shade['bleName']}'")
+                print(f"\tHomeKey: {key.hex()} (shade unreachable, using network key)")
+            else:
+                print(f"Shade '{name}':")
+                print(f"\tBLE name: '{shade['bleName']}'")
+                print(f"\tHomeKey: ERROR - {ex}")
+            continue
 
         print(f"Shade '{name}':")
         print(f"\tBLE name: '{shade['bleName']}'")

--- a/scripts/shade_report.py
+++ b/scripts/shade_report.py
@@ -5,15 +5,15 @@ to the Home Assistant integration code. Fetches the shade's homekey
 from a G3 Gateway, scans for the BLE advertisement, then dumps:
   1. BLE advertisement (raw + decoded)
   2. Standard GATT device-info characteristics
-  3. Read-only PowerView queries:
-       - 0xF1DD product info
-       - 0xFFDD HW diagnostics (contains serial / firmware / type / model)
-       - 0xFFDE power status (battery vs. hardwired)
+  3. Decoded read-only PowerView queries:
+       - 0xFFDD sel=4 product info        (firm update count, sw_rev)
+       - 0xFFDD sel=5 extended product info (serial, fw/sw/hw_rev, type)
+       - 0xFFDE power status              (hardwired vs battery, level)
 
 Dependencies:  bleak, bleak-retry-connector, cryptography, requests  (no HA)
 
-SAFETY: only the three read-only opcodes above are ever sent. No
-set/move/scene/rekey/factory-reset opcodes are implemented here.
+SAFETY: only the read-only opcodes above are ever sent. No set/move/
+scene/rekey/factory-reset opcodes are implemented here.
 
 Usage:
     python scripts/shade_report.py --ble-name PV-XXXXXX
@@ -70,17 +70,21 @@ GATT_DEV_INFO: list[tuple[str, str]] = [
 # (e.g. 0x01F7 move, 0xFA5A set-scene, 0xFB02 rekey, 0xFFDF set-power-
 # type, 0xFFEE factory-reset).
 #
-# Observed (fw_rev=22, Duette type 6, hardwired):
-#   0xF1DD → 1-byte `04` payload on len=0 input; 2-byte `8c 00` on len=1;
-#            `04` again for len=2/4/8.  The `8c 00` response is IDENTICAL
-#            to what 0xFFDD returns at len=1, so it's a shared reject
-#            path, not real data.  Conclusion: F1DD is either disabled or
-#            gated on specific non-zero parameter bytes we haven't found.
-#            Standard GATT chars (2a24-2a29) already give us the product
-#            info this opcode would have returned.
-#   0xFFDD → same signature as F1DD: `04` at len∈{0,2,4,8}, `8c 00` at
-#            len=1.  Same conclusion — superseded by GATT 180A service
-#            (manufacturer/model/serial/hw_rev/fw_rev/sw_rev).
+# Decoded queries (fw_rev=22, Duette type 6, hardwired):
+#   0xFFDD → product-info opcode gated on a 1-byte selector.  sel=4
+#            returns a 14-byte page (firm update count u32 LE at bytes
+#            2-5, firm current version u16 LE at bytes 6-7 matching
+#            GATT sw_rev).  sel=5 returns a 28-byte extended page with
+#            every field confirmed against GATT Device Information:
+#            serial (bytes 2-9, little-endian), fw_rev (10-11), sw_rev
+#            (14-15), hw_rev (18-21 u32 LE), build/mfg id (22-25), and
+#            type_id (26) matching the advertisement.  Decoded in
+#            annotate_query.  0xF1DD returns the same sel=4 page and
+#            a truncated 22-byte sel=5 (no trailing 6 bytes); not
+#            queried separately since its data is a strict subset.
+#            The emulator's ret_valFFDD (29 B, labelled "HW
+#            diagnostics") is actually this extended product info with
+#            dummy data, off-by-one vs real firmware.
 #   0xFFDE → 8-byte payload.  Byte-by-byte findings on hardwired Duette
 #            (type 6, fw_rev=22), verified across four shades and ~10
 #            targeted motion/idle experiments on one unit:
@@ -125,10 +129,16 @@ GATT_DEV_INFO: list[tuple[str, str]] = [
 #            0xFFDE remains the only reliable source for battery-vs-
 #            hardwired detection (the advert's 2-bit level field caps
 #            at 3 = "100% OR hardwired" and cannot disambiguate).
-GET_QUERIES: list[tuple[int, str]] = [
-    (0xF1DD, "product info"),
-    (0xFFDD, "HW diagnostics"),
-    (0xFFDE, "power status"),
+# (cmd, payload, label) — each entry is a query that returns real
+# decoded data on fw_rev=22.  0xFFDD's two selectors are complementary:
+# sel=4 carries firm update count + firm current version; sel=5 carries
+# serial / fw_rev / sw_rev / hw_rev / build id / type_id.  0xF1DD is a
+# strict subset of 0xFFDD (same sel=4 bytes; sel=5 drops the trailing 6)
+# so it's not queried separately.
+GET_QUERIES: list[tuple[int, bytes, str]] = [
+    (0xFFDD, b"\x04", "product info (sel=4)"),
+    (0xFFDD, b"\x05", "ext product info (sel=5)"),
+    (0xFFDE, b"", "power status"),
 ]
 
 # Advert level field is 2 bits, so only values 0-3 are observable on the wire.
@@ -141,15 +151,6 @@ PV_ERROR_CODES: dict[int, str] = {
     0x04: "invalid length (hypothesis)",
 }
 
-# Observed two-byte error signatures.  fw_rev=22 returns `8c 00` for both
-# 0xF1DD and 0xFFDD with a 1-byte input — identical bytes across two
-# semantically different opcodes, so this is a shared reject path rather
-# than opcode-specific data.  Suspected meaning: "unsupported / bad
-# parameter", but not confirmed.
-PV_ERROR_SIGNATURES_2B: dict[bytes, str] = {
-    b"\x8c\x00": "generic reject (hypothesis; fw_rev=22, F1DD+FFDD)",
-}
-
 # 0xFFDE byte 0 — power type.  0 is confirmed hardwired on fw_rev=22.
 # 1/2 are hypotheses pending sample data from battery/rechargeable shades.
 POWER_TYPE_LABELS: dict[int, str] = {
@@ -158,12 +159,18 @@ POWER_TYPE_LABELS: dict[int, str] = {
     2: "rechargeable (hypothesis)",
 }
 
-# Emulator-confirmed success-response lengths (see emu/PV_BLE_cover.ino).
-# Used to flag a real shade's 1-byte reply as "way shorter than expected".
-EXPECTED_QUERY_LEN: dict[int, int] = {
-    0xF1DD: 14,
-    0xFFDD: 29,
-    0xFFDE: 8,
+# Known-good response lengths per opcode.  Used only by annotate_query
+# to decide whether a 1-byte reply should be interpreted as an error
+# code (i.e. "we expected a longer payload and got a single byte — that
+# byte is the error").  0xFFDD has two valid shapes because its two
+# queried selectors return different lengths; 0xF1DD's 14- and 22-byte
+# shapes are retained for completeness even though the script no longer
+# queries that opcode directly.  Emulator's 0xFFDD dummy is 29 B but
+# real fw_rev=22 returns 28 B at sel=5 — treat emulator as off-by-one.
+EXPECTED_QUERY_LEN: dict[int, set[int]] = {
+    0xF1DD: {14, 22},
+    0xFFDD: {14, 28},
+    0xFFDE: {8},
 }
 
 SCAN_TIMEOUT = 30.0
@@ -322,16 +329,100 @@ def annotate_query(cmd: int, payload: bytes) -> str | None:
     marked "hypothesis" still needs cross-shade confirmation — that's
     the whole point of this report.
     """
-    expected = EXPECTED_QUERY_LEN.get(cmd)
+    expected = EXPECTED_QUERY_LEN.get(cmd, set())
     # Shade returned a 1-byte reply where we know a longer one is valid:
     # standard PowerView error-response shape — byte is an error code.
-    if expected and len(payload) == 1 and expected > 1:
+    if expected and len(payload) == 1 and 1 not in expected:
         err = payload[0]
         note = PV_ERROR_CODES.get(err, "unknown error code")
+        good = ", ".join(str(n) for n in sorted(expected))
         return (
             f"likely error code 0x{err:02X} ({note}); "
-            f"emulator returns {expected} B on success"
+            f"known good lengths: {good} B"
         )
+    # Two-byte `8c XX` rejection: byte 0 is a fixed reject code, byte 1
+    # echoes the bad input byte (observed for selector=0 and selector=3
+    # on fw_rev=22, where the selector is the first byte of the query
+    # payload).  Decoding this helps distinguish "bad selector" from
+    # other short error shapes.
+    if len(payload) == 2 and payload[0] == 0x8C:
+        return (
+            f"rejection (0x8C) — selector 0x{payload[1]:02X} "
+            f"({payload[1]}) not supported by this opcode"
+        )
+    # 14-byte product-info page, returned by 0xF1DD and 0xFFDD when the
+    # payload's first byte is 0x04.  The two opcodes return the same
+    # bytes here (sel=5 is where they diverge — see below).  Confirmed
+    # on fw_rev=22: byte 1 echoes the selector (0x04), bytes 2-5 are a
+    # u32 counter (=1 on a freshly-imaged shade), and bytes 6-7 LE are
+    # the firmware version (matches GATT sw_rev exactly — the emulator
+    # also embeds SW_VERSION there in its ret_valF1DD dummy).  Bytes
+    # 8-13 are zero on our samples; meaning unknown.
+    if cmd in (0xF1DD, 0xFFDD) and len(payload) == 14 and payload[1] == 0x04:
+        counter = int.from_bytes(payload[2:6], "little")
+        firm_current = int.from_bytes(payload[6:8], "little")
+        indent = "           "
+        return (
+            "14-byte product info (selector=0x04). Fields:\n"
+            f"{indent}byte 1 = 0x{payload[1]:02X} → echoed selector\n"
+            f"{indent}bytes 2-5 = {payload[2:6].hex(' ')} → "
+            f"counter={counter} (u32 LE; hypothesis — firm update count?)\n"
+            f"{indent}bytes 6-7 = {payload[6:8].hex(' ')} → firm current "
+            f"version={firm_current} (confirmed; matches GATT sw_rev)\n"
+            f"{indent}bytes 8-13 = {payload[8:14].hex(' ')} → unknown "
+            f"(zero on all samples)"
+        )
+    # Extended product info (selector=0x05).  0xF1DD returns a 22-byte
+    # subset; 0xFFDD returns 28 bytes (same first 22 plus 4-byte build/
+    # mfg counter + type_id + model byte).  Every field below is
+    # confirmed against GATT Device Information on fw_rev=22:
+    #   bytes 2-9   = 8-byte serial LE (matches GATT 0x2a25 hex-reversed)
+    #   bytes 10-11 = u16 LE fw_rev   (matches GATT 0x2a26)
+    #   bytes 14-15 = u16 LE sw_rev   (matches GATT 0x2a28)
+    #   bytes 18-21 = u32 LE hw_rev   (matches GATT 0x2a27)
+    # The FFDD-only tail is still provisional — byte 26 matches the
+    # advert's type_id; bytes 22-25 look like another 32-bit identifier
+    # (1015780 on the "Study" shade), and byte 27 is a model/family byte.
+    if (
+        cmd in (0xF1DD, 0xFFDD)
+        and len(payload) in (22, 28)
+        and payload[1] == 0x05
+    ):
+        serial_hex = payload[2:10][::-1].hex().upper()
+        fw_rev = int.from_bytes(payload[10:12], "little")
+        sw_rev = int.from_bytes(payload[14:16], "little")
+        hw_rev = int.from_bytes(payload[18:22], "little")
+        indent = "           "
+        lines = [
+            f"{len(payload)}-byte extended product info (selector=0x05). "
+            "Fields (all confirmed vs GATT):",
+            f"{indent}byte 1 = 0x{payload[1]:02X} → echoed selector",
+            f"{indent}bytes 2-9 = {payload[2:10].hex(' ')} → "
+            f"serial={serial_hex} (LE; matches GATT 0x2a25)",
+            f"{indent}bytes 10-11 = {payload[10:12].hex(' ')} → "
+            f"fw_rev={fw_rev} (matches GATT 0x2a26)",
+            f"{indent}bytes 12-13 = {payload[12:14].hex(' ')} → "
+            "reserved (zero on samples)",
+            f"{indent}bytes 14-15 = {payload[14:16].hex(' ')} → "
+            f"sw_rev={sw_rev} (matches GATT 0x2a28)",
+            f"{indent}bytes 16-17 = {payload[16:18].hex(' ')} → "
+            "reserved (zero on samples)",
+            f"{indent}bytes 18-21 = {payload[18:22].hex(' ')} → "
+            f"hw_rev={hw_rev} (matches GATT 0x2a27)",
+        ]
+        if len(payload) == 28:
+            build_id = int.from_bytes(payload[22:26], "little")
+            lines.extend(
+                [
+                    f"{indent}bytes 22-25 = {payload[22:26].hex(' ')} → "
+                    f"build/mfg id={build_id} (u32 LE; hypothesis)",
+                    f"{indent}byte 26 = 0x{payload[26]:02X} → "
+                    f"type_id={payload[26]} (matches advert)",
+                    f"{indent}byte 27 = 0x{payload[27]:02X} → "
+                    "model/family byte (hypothesis)",
+                ]
+            )
+        return "\n".join(lines)
     if cmd == 0xFFDE and len(payload) == 8:
         pt = payload[0]
         label = POWER_TYPE_LABELS.get(pt, f"unknown ({pt})")
@@ -360,52 +451,6 @@ def annotate_query(cmd: int, payload: bytes) -> str | None:
             f"{indent}byte 7 = 0x{payload[7]:02X} → reserved/padding"
         )
     return None
-
-
-# Payload lengths to try when --probe is set.  Small, zero-filled inputs
-# only — we are varying length to see which values the firmware accepts,
-# not guessing parameter content.  Kept short because longer sweeps take
-# longer to run and each probe is an encrypted BLE round-trip.
-PROBE_LENGTHS: list[int] = [0, 1, 2, 4, 8]
-
-# Opcodes we'll probe.  MUST only contain documented read-only GETs;
-# never add a SET/move/scene/rekey/reset opcode here (see SAFETY note in
-# the module docstring).
-PROBE_OPCODES: list[tuple[int, str]] = [
-    (0xF1DD, "product info"),
-    (0xFFDD, "HW diagnostics"),
-]
-
-
-async def probe_opcode(api: PowerViewClient, cmd: int, label: str) -> None:
-    """Sweep zero-filled input payloads across PROBE_LENGTHS.
-
-    Tag policy: `HIT` only when the response length matches what the
-    emulator returns on success (EXPECTED_QUERY_LEN).  Anything shorter
-    is flagged `short?`; shorter-than-3 is almost certainly an error
-    shape — fw_rev=22 has been observed returning both 1-byte (`04`)
-    and 2-byte (`8c 00`) rejections, the latter being the *same* for
-    different opcodes, so a short payload is not proof of a real hit.
-    """
-    expected = EXPECTED_QUERY_LEN.get(cmd, 0)
-    print(f"  0x{cmd:04X} {label} (expect {expected} B on success):")
-    for n in PROBE_LENGTHS:
-        data = bytes(n)
-        try:
-            payload = await api.query(cmd, data)
-            if expected and len(payload) == expected:
-                tag = "HIT   "
-            elif len(payload) < 3:
-                tag = "error?"
-            else:
-                tag = "short?"
-            hex_display = payload.hex(" ") if payload else "(empty)"
-            print(
-                f"    len={n:2} → "
-                f"{tag} ({len(payload):2} B): {hex_display}"
-            )
-        except Exception as ex:  # noqa: BLE001
-            print(f"    len={n:2} → FAILED — {ex}")
 
 
 def _print_advertisement(device: BLEDevice, adv: AdvertisementData) -> None:
@@ -446,28 +491,18 @@ async def _print_gatt_info(api: PowerViewClient) -> None:
 
 async def _print_queries(api: PowerViewClient) -> None:
     """Print section 3: read-only protocol queries."""
-    for cmd, label in GET_QUERIES:
+    for cmd, req, label in GET_QUERIES:
         try:
-            payload = await api.query(cmd)
+            resp = await api.query(cmd, req)
             print(
-                f"  0x{cmd:04X} {label:16} "
-                f"({len(payload):2} B): {payload.hex(' ')}"
+                f"  0x{cmd:04X} {label:25} "
+                f"({len(resp):2} B): {resp.hex(' ')}"
             )
-            note = annotate_query(cmd, payload)
+            note = annotate_query(cmd, resp)
             if note:
                 print(f"         → {note}")
         except Exception as ex:  # noqa: BLE001
-            print(f"  0x{cmd:04X} {label:16} FAILED — {ex}")
-            break
-
-
-async def _print_probe(api: PowerViewClient) -> None:
-    """Print section 4: payload-length sweep over read-only probe opcodes."""
-    for cmd, label in PROBE_OPCODES:
-        try:
-            await probe_opcode(api, cmd, label)
-        except Exception as ex:  # noqa: BLE001
-            print(f"  0x{cmd:04X} probe aborted — {ex}")
+            print(f"  0x{cmd:04X} {label:25} FAILED — {ex}")
             break
 
 
@@ -477,7 +512,6 @@ async def report_shade(
     home_key: bytes,
     device: BLEDevice | None,
     adv: AdvertisementData | None,
-    probe: bool = False,
 ) -> None:
     """Print the full report for a single shade: advertisement + GATT + queries."""
     print(f"\n=== '{friendly_name}'  (BLE: {ble_name}) ===")
@@ -495,10 +529,6 @@ async def report_shade(
         _section("3. Protocol queries (read-only)")
         await _print_queries(api)
 
-        if probe:
-            _section("4. Probe (payload-length sweep, read-only opcodes)")
-            await _print_probe(api)
-
 
 # --- Main ----------------------------------------------------------
 PER_SHADE_TIMEOUT = 45.0  # hard cap on total time spent per shade's report
@@ -510,7 +540,6 @@ async def run(
     all_shades: bool,
     scan_timeout: float,
     verbose: bool,
-    probe: bool = False,
 ) -> int:
     """Fetch the shade list, homekey, then report on each target."""
     if verbose:
@@ -569,7 +598,7 @@ async def run(
         # Per-shade timeout so one unreachable shade can't stall the whole run.
         try:
             await asyncio.wait_for(
-                report_shade(friendly, ble, home_key, dev, adv, probe=probe),
+                report_shade(friendly, ble, home_key, dev, adv),
                 timeout=PER_SHADE_TIMEOUT,
             )
         except TimeoutError:
@@ -599,15 +628,6 @@ def main() -> int:
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable debug logging"
     )
-    parser.add_argument(
-        "--probe",
-        action="store_true",
-        help=(
-            "Sweep payload lengths for 0xF1DD/0xFFDD to find what the "
-            "firmware accepts.  Read-only; slow (one BLE round-trip per "
-            "length).  Share the output to help decode these opcodes."
-        ),
-    )
     args = parser.parse_args()
 
     targets: list[tuple[str, str]] | None = None
@@ -620,7 +640,6 @@ def main() -> int:
             args.all,
             args.scan_timeout,
             args.verbose,
-            probe=args.probe,
         )
     )
 

--- a/scripts/shade_report.py
+++ b/scripts/shade_report.py
@@ -81,28 +81,58 @@ GATT_DEV_INFO: list[tuple[str, str]] = [
 #   0xFFDD → same signature as F1DD: `04` at len∈{0,2,4,8}, `8c 00` at
 #            len=1.  Same conclusion — superseded by GATT 180A service
 #            (manufacturer/model/serial/hw_rev/fw_rev/sw_rev).
-#   0xFFDE → 8-byte payload `XX ?? ?? ?? ?? ?? tt 00` where:
-#              byte 0 (XX) = power type — 0 = hardwired (confirmed);
-#                            1 = battery, 2 = rechargeable (hypothesis,
-#                            unconfirmed — no non-hardwired shade
-#                            sampled yet).
-#              byte 6 (tt) = shade type_id (matches advertisement byte 2)
-#            Bytes 1-5 and 7 are unidentified.  They are NOT the coarse
-#            battery % — that already lives in the advert's 2-bit level
-#            field (decoded above into `level_bits`).  Candidates for
-#            the unknown bytes: pack-health %, cycle counter, calibration
-#            values, firmware constants.  Reports from non-hardwired
-#            shades are needed to pin them down.
-#            0xFFDE is the reliable source for battery-vs-hardwired
-#            detection.  The advertisement's 2-bit level field maxes at
-#            3 ("100% or hardwired") and cannot disambiguate the two.
+#   0xFFDE → 8-byte payload.  Byte-by-byte findings on hardwired Duette
+#            (type 6, fw_rev=22), verified across four shades and ~10
+#            targeted motion/idle experiments on one unit:
+#              b0 power_type   0=hardwired (confirmed); 1=battery,
+#                              2=rechargeable (hypothesis — no non-
+#                              hardwired sample yet).
+#              b1 = 0x01       constant on all hardwired shades seen.
+#                              Likely a power-type subvariant or flags
+#                              byte; pending a non-hardwired sample.
+#              b2 = 0x64 (100) strong hypothesis: battery/power-level
+#                              %, pegged at 100 on wall power.  A
+#                              battery shade should report its real %
+#                              here.  NOT a duplicate of the advert's
+#                              2-bit level field — this is the full
+#                              byte-resolution value.
+#              b3              live / noisy byte — read-to-read drift
+#                              of 3-9 counts with no physical change.
+#                              Too jittery to be temperature; best
+#                              guess is radio or ADC telemetry.  Not
+#                              practically useful without a burst-
+#                              capture characterization.
+#              b4 = 0x07       constant on all hardwired shades seen.
+#                              Likely capability or power-config flags.
+#              b5              persistent per-shade state.  Observed
+#                              to change exactly once across ~10
+#                              experiments on one unit (227 -> 205
+#                              during the first commanded move of a
+#                              session).  Each idle shade holds its
+#                              own stable value (114/127/139/205 seen
+#                              at position=100%).  Triggers RULED OUT:
+#                              every move, cold-start after 15-min
+#                              idle, short-period timer, distance-
+#                              gated motion snapshot, top & bottom
+#                              end-stop calibration.  Remaining
+#                              candidates: boot-triggered state,
+#                              long-period (hours+) timer, or hub-
+#                              initiated refresh.
+#              b6 type_id      matches advertisement byte 2 (confirmed).
+#              b7 = 0x00       reserved / padding on all observations.
+#            All b1-b7 findings are fw_rev=22 hardwired-only; re-verify
+#            on battery / rechargeable hardware before relying on them.
+#            0xFFDE remains the only reliable source for battery-vs-
+#            hardwired detection (the advert's 2-bit level field caps
+#            at 3 = "100% OR hardwired" and cannot disambiguate).
 GET_QUERIES: list[tuple[int, str]] = [
     (0xF1DD, "product info"),
     (0xFFDD, "HW diagnostics"),
     (0xFFDE, "power status"),
 ]
 
-POWER_LEVELS = {4: 100, 3: 100, 2: 50, 1: 20, 0: 0}
+# Advert level field is 2 bits, so only values 0-3 are observable on the wire.
+POWER_LEVELS = {3: 100, 2: 50, 1: 20, 0: 0}
 
 # PowerView BLE error-response shape (see api.py _verify_response): when a
 # query's response has data_len=1, byte 4 is an error code rather than real
@@ -305,16 +335,29 @@ def annotate_query(cmd: int, payload: bytes) -> str | None:
     if cmd == 0xFFDE and len(payload) == 8:
         pt = payload[0]
         label = POWER_TYPE_LABELS.get(pt, f"unknown ({pt})")
-        # Only byte 0 (power type) and byte 6 (type_id) are identified.
-        # Battery % already comes from the advert's 2-bit level field, so
-        # byte 2 is NOT a battery-% duplicate.  Bytes 1-5 and 7 remain
-        # unknown — plausible candidates include pack health %, cycle
-        # counters, calibration values, or firmware constants.  Reports
-        # from non-hardwired shades should help disambiguate.
+        # Per-byte interpretations as of 2026-04-21 investigation (see
+        # module-level comment for the experiment log).  b0 and b6 are
+        # confirmed; b1/b2/b4/b7 are strong hypotheses based on four
+        # hardwired shades at fw_rev=22; b3 is a live noisy byte; b5 is
+        # persistent per-shade state with an unknown refresh trigger.
+        # 11-space indent on continuation lines aligns with the "→ "
+        # prefix added by _print_queries (9 spaces + arrow + space).
+        indent = "           "
         return (
-            f"power_type={pt} ({label}), type_id={payload[6]} "
-            f"(cross-check with advert). Other bytes unidentified — "
-            f"share them verbatim to help decode."
+            f"byte 0 = 0x{payload[0]:02X} → power_type={pt} ({label})\n"
+            f"{indent}byte 1 = 0x{payload[1]:02X} → power-subtype/flags "
+            f"(const 0x01 on hardwired; hypothesis)\n"
+            f"{indent}byte 2 = 0x{payload[2]:02X} ({payload[2]}) → "
+            f"battery/power level % (hypothesis — pegged at 100 on hardwired)\n"
+            f"{indent}byte 3 = 0x{payload[3]:02X} → live/noisy byte "
+            f"(drifts between reads; radio or ADC telemetry)\n"
+            f"{indent}byte 4 = 0x{payload[4]:02X} → capability/config flags "
+            f"(const 0x07 on hardwired; hypothesis)\n"
+            f"{indent}byte 5 = 0x{payload[5]:02X} → persistent per-shade state "
+            f"(rarely updates; refresh trigger unknown)\n"
+            f"{indent}byte 6 = 0x{payload[6]:02X} → type_id={payload[6]} "
+            f"(cross-check with advert)\n"
+            f"{indent}byte 7 = 0x{payload[7]:02X} → reserved/padding"
         )
     return None
 
@@ -387,8 +430,7 @@ def _print_advertisement(device: BLEDevice, adv: AdvertisementData) -> None:
         f"charging_flag={decoded['charging_flag']}"
     )
     print(
-        f"  level:    bits={decoded['level_bits']} "
-        f"(→ {decoded['level_pct']}%; cannot report hardwired=4)"
+        f"  level:    bits={decoded['level_bits']} (→ {decoded['level_pct']}%)"
     )
 
 

--- a/scripts/shade_report.py
+++ b/scripts/shade_report.py
@@ -71,16 +71,28 @@ GATT_DEV_INFO: list[tuple[str, str]] = [
 # type, 0xFFEE factory-reset).
 #
 # Observed (fw_rev=22, Duette type 6, hardwired):
-#   0xF1DD → 1-byte `04` payload.  Possibly erroring (err code 4 =
-#            Invalid Length) or this firmware genuinely returns a stub.
-#   0xFFDD → 1-byte `04` payload.  Same caveat as F1DD.
-#   0xFFDE → 8-byte payload `XX 01 pp ?? ?? ?? tt 00` where:
+#   0xF1DD → 1-byte `04` payload on len=0 input; 2-byte `8c 00` on len=1;
+#            `04` again for len=2/4/8.  The `8c 00` response is IDENTICAL
+#            to what 0xFFDD returns at len=1, so it's a shared reject
+#            path, not real data.  Conclusion: F1DD is either disabled or
+#            gated on specific non-zero parameter bytes we haven't found.
+#            Standard GATT chars (2a24-2a29) already give us the product
+#            info this opcode would have returned.
+#   0xFFDD → same signature as F1DD: `04` at len∈{0,2,4,8}, `8c 00` at
+#            len=1.  Same conclusion — superseded by GATT 180A service
+#            (manufacturer/model/serial/hw_rev/fw_rev/sw_rev).
+#   0xFFDE → 8-byte payload `XX ?? ?? ?? ?? ?? tt 00` where:
 #              byte 0 (XX) = power type — 0 = hardwired (confirmed);
 #                            1 = battery, 2 = rechargeable (hypothesis,
-#                            unconfirmed — file firmware lacks a
-#                            non-hardwired shade to sample).
-#              byte 2 (pp) = position %
+#                            unconfirmed — no non-hardwired shade
+#                            sampled yet).
 #              byte 6 (tt) = shade type_id (matches advertisement byte 2)
+#            Bytes 1-5 and 7 are unidentified.  They are NOT the coarse
+#            battery % — that already lives in the advert's 2-bit level
+#            field (decoded above into `level_bits`).  Candidates for
+#            the unknown bytes: pack-health %, cycle counter, calibration
+#            values, firmware constants.  Reports from non-hardwired
+#            shades are needed to pin them down.
 #            0xFFDE is the reliable source for battery-vs-hardwired
 #            detection.  The advertisement's 2-bit level field maxes at
 #            3 ("100% or hardwired") and cannot disambiguate the two.
@@ -91,6 +103,38 @@ GET_QUERIES: list[tuple[int, str]] = [
 ]
 
 POWER_LEVELS = {4: 100, 3: 100, 2: 50, 1: 20, 0: 0}
+
+# PowerView BLE error-response shape (see api.py _verify_response): when a
+# query's response has data_len=1, byte 4 is an error code rather than real
+# payload.  Expand this dict as users report codes from different firmwares.
+PV_ERROR_CODES: dict[int, str] = {
+    0x04: "invalid length (hypothesis)",
+}
+
+# Observed two-byte error signatures.  fw_rev=22 returns `8c 00` for both
+# 0xF1DD and 0xFFDD with a 1-byte input — identical bytes across two
+# semantically different opcodes, so this is a shared reject path rather
+# than opcode-specific data.  Suspected meaning: "unsupported / bad
+# parameter", but not confirmed.
+PV_ERROR_SIGNATURES_2B: dict[bytes, str] = {
+    b"\x8c\x00": "generic reject (hypothesis; fw_rev=22, F1DD+FFDD)",
+}
+
+# 0xFFDE byte 0 — power type.  0 is confirmed hardwired on fw_rev=22.
+# 1/2 are hypotheses pending sample data from battery/rechargeable shades.
+POWER_TYPE_LABELS: dict[int, str] = {
+    0: "hardwired",
+    1: "battery (hypothesis)",
+    2: "rechargeable (hypothesis)",
+}
+
+# Emulator-confirmed success-response lengths (see emu/PV_BLE_cover.ino).
+# Used to flag a real shade's 1-byte reply as "way shorter than expected".
+EXPECTED_QUERY_LEN: dict[int, int] = {
+    0xF1DD: 14,
+    0xFFDD: 29,
+    0xFFDE: 8,
+}
 
 SCAN_TIMEOUT = 30.0
 CMD_TIMEOUT = 30.0
@@ -241,12 +285,157 @@ def _section(title: str) -> None:
     print(f"  {'-' * len(title)}")
 
 
+def annotate_query(cmd: int, payload: bytes) -> str | None:
+    """Return a one-line decode of a query response, or None if unknown.
+
+    Printed beneath the raw hex so reporters see both.  Everything
+    marked "hypothesis" still needs cross-shade confirmation — that's
+    the whole point of this report.
+    """
+    expected = EXPECTED_QUERY_LEN.get(cmd)
+    # Shade returned a 1-byte reply where we know a longer one is valid:
+    # standard PowerView error-response shape — byte is an error code.
+    if expected and len(payload) == 1 and expected > 1:
+        err = payload[0]
+        note = PV_ERROR_CODES.get(err, "unknown error code")
+        return (
+            f"likely error code 0x{err:02X} ({note}); "
+            f"emulator returns {expected} B on success"
+        )
+    if cmd == 0xFFDE and len(payload) == 8:
+        pt = payload[0]
+        label = POWER_TYPE_LABELS.get(pt, f"unknown ({pt})")
+        # Only byte 0 (power type) and byte 6 (type_id) are identified.
+        # Battery % already comes from the advert's 2-bit level field, so
+        # byte 2 is NOT a battery-% duplicate.  Bytes 1-5 and 7 remain
+        # unknown — plausible candidates include pack health %, cycle
+        # counters, calibration values, or firmware constants.  Reports
+        # from non-hardwired shades should help disambiguate.
+        return (
+            f"power_type={pt} ({label}), type_id={payload[6]} "
+            f"(cross-check with advert). Other bytes unidentified — "
+            f"share them verbatim to help decode."
+        )
+    return None
+
+
+# Payload lengths to try when --probe is set.  Small, zero-filled inputs
+# only — we are varying length to see which values the firmware accepts,
+# not guessing parameter content.  Kept short because longer sweeps take
+# longer to run and each probe is an encrypted BLE round-trip.
+PROBE_LENGTHS: list[int] = [0, 1, 2, 4, 8]
+
+# Opcodes we'll probe.  MUST only contain documented read-only GETs;
+# never add a SET/move/scene/rekey/reset opcode here (see SAFETY note in
+# the module docstring).
+PROBE_OPCODES: list[tuple[int, str]] = [
+    (0xF1DD, "product info"),
+    (0xFFDD, "HW diagnostics"),
+]
+
+
+async def probe_opcode(api: PowerViewClient, cmd: int, label: str) -> None:
+    """Sweep zero-filled input payloads across PROBE_LENGTHS.
+
+    Tag policy: `HIT` only when the response length matches what the
+    emulator returns on success (EXPECTED_QUERY_LEN).  Anything shorter
+    is flagged `short?`; shorter-than-3 is almost certainly an error
+    shape — fw_rev=22 has been observed returning both 1-byte (`04`)
+    and 2-byte (`8c 00`) rejections, the latter being the *same* for
+    different opcodes, so a short payload is not proof of a real hit.
+    """
+    expected = EXPECTED_QUERY_LEN.get(cmd, 0)
+    print(f"  0x{cmd:04X} {label} (expect {expected} B on success):")
+    for n in PROBE_LENGTHS:
+        data = bytes(n)
+        try:
+            payload = await api.query(cmd, data)
+            if expected and len(payload) == expected:
+                tag = "HIT   "
+            elif len(payload) < 3:
+                tag = "error?"
+            else:
+                tag = "short?"
+            hex_display = payload.hex(" ") if payload else "(empty)"
+            print(
+                f"    len={n:2} → "
+                f"{tag} ({len(payload):2} B): {hex_display}"
+            )
+        except Exception as ex:  # noqa: BLE001
+            print(f"    len={n:2} → FAILED — {ex}")
+
+
+def _print_advertisement(device: BLEDevice, adv: AdvertisementData) -> None:
+    """Print section 1: the BLE advertisement (raw + decoded)."""
+    print(f"  address:  {device.address}")
+    print(f"  rssi:     {adv.rssi} dBm")
+    manuf = adv.manufacturer_data.get(MFCT_ID, b"")
+    print(f"  raw:      {manuf.hex(' ') if manuf else '(none)'}")
+    decoded = decode_adv(manuf)
+    if not decoded:
+        return
+    print(f"  home_id:  0x{decoded['home_id']:04x}")
+    print(f"  type_id:  {decoded['type_id']}")
+    print(
+        f"  position: {decoded['position']}  "
+        f"pos2={decoded['position2']}  pos3={decoded['position3']}  "
+        f"tilt={decoded['tilt']}"
+    )
+    print(
+        f"  flags:    opening={decoded['opening']}  "
+        f"closing={decoded['closing']}  "
+        f"charging_flag={decoded['charging_flag']}"
+    )
+    print(
+        f"  level:    bits={decoded['level_bits']} "
+        f"(→ {decoded['level_pct']}%; cannot report hardwired=4)"
+    )
+
+
+async def _print_gatt_info(api: PowerViewClient) -> None:
+    """Print section 2: standard GATT device-info characteristics."""
+    for key, uuid in GATT_DEV_INFO:
+        try:
+            value = (await api.read_gatt(uuid)).decode("utf-8", errors="replace")
+            print(f"  {key:13} {value}")
+        except Exception as ex:  # noqa: BLE001
+            print(f"  {key:13} <error: {ex}>")
+
+
+async def _print_queries(api: PowerViewClient) -> None:
+    """Print section 3: read-only protocol queries."""
+    for cmd, label in GET_QUERIES:
+        try:
+            payload = await api.query(cmd)
+            print(
+                f"  0x{cmd:04X} {label:16} "
+                f"({len(payload):2} B): {payload.hex(' ')}"
+            )
+            note = annotate_query(cmd, payload)
+            if note:
+                print(f"         → {note}")
+        except Exception as ex:  # noqa: BLE001
+            print(f"  0x{cmd:04X} {label:16} FAILED — {ex}")
+            break
+
+
+async def _print_probe(api: PowerViewClient) -> None:
+    """Print section 4: payload-length sweep over read-only probe opcodes."""
+    for cmd, label in PROBE_OPCODES:
+        try:
+            await probe_opcode(api, cmd, label)
+        except Exception as ex:  # noqa: BLE001
+            print(f"  0x{cmd:04X} probe aborted — {ex}")
+            break
+
+
 async def report_shade(
     friendly_name: str,
     ble_name: str,
     home_key: bytes,
     device: BLEDevice | None,
     adv: AdvertisementData | None,
+    probe: bool = False,
 ) -> None:
     """Print the full report for a single shade: advertisement + GATT + queries."""
     print(f"\n=== '{friendly_name}'  (BLE: {ble_name}) ===")
@@ -255,49 +444,18 @@ async def report_shade(
     if device is None or adv is None:
         print("  not seen on air within scan window — skipping BLE queries")
         return
-    print(f"  address:  {device.address}")
-    print(f"  rssi:     {adv.rssi} dBm")
-    manuf = adv.manufacturer_data.get(MFCT_ID, b"")
-    print(f"  raw:      {manuf.hex(' ') if manuf else '(none)'}")
-    decoded = decode_adv(manuf)
-    if decoded:
-        print(f"  home_id:  0x{decoded['home_id']:04x}")
-        print(f"  type_id:  {decoded['type_id']}")
-        print(
-            f"  position: {decoded['position']}  "
-            f"pos2={decoded['position2']}  pos3={decoded['position3']}  "
-            f"tilt={decoded['tilt']}"
-        )
-        print(
-            f"  flags:    opening={decoded['opening']}  "
-            f"closing={decoded['closing']}  "
-            f"charging_flag={decoded['charging_flag']}"
-        )
-        print(
-            f"  level:    bits={decoded['level_bits']} "
-            f"(→ {decoded['level_pct']}%; cannot report hardwired=4)"
-        )
+    _print_advertisement(device, adv)
 
     async with PowerViewClient(device, home_key) as api:
         _section("2. GATT device info")
-        for key, uuid in GATT_DEV_INFO:
-            try:
-                value = (await api.read_gatt(uuid)).decode("utf-8", errors="replace")
-                print(f"  {key:13} {value}")
-            except Exception as ex:  # noqa: BLE001
-                print(f"  {key:13} <error: {ex}>")
+        await _print_gatt_info(api)
 
         _section("3. Protocol queries (read-only)")
-        for cmd, label in GET_QUERIES:
-            try:
-                payload = await api.query(cmd)
-                print(
-                    f"  0x{cmd:04X} {label:16} "
-                    f"({len(payload):2} B): {payload.hex(' ')}"
-                )
-            except Exception as ex:  # noqa: BLE001
-                print(f"  0x{cmd:04X} {label:16} FAILED — {ex}")
-                break
+        await _print_queries(api)
+
+        if probe:
+            _section("4. Probe (payload-length sweep, read-only opcodes)")
+            await _print_probe(api)
 
 
 # --- Main ----------------------------------------------------------
@@ -310,6 +468,7 @@ async def run(
     all_shades: bool,
     scan_timeout: float,
     verbose: bool,
+    probe: bool = False,
 ) -> int:
     """Fetch the shade list, homekey, then report on each target."""
     if verbose:
@@ -368,7 +527,7 @@ async def run(
         # Per-shade timeout so one unreachable shade can't stall the whole run.
         try:
             await asyncio.wait_for(
-                report_shade(friendly, ble, home_key, dev, adv),
+                report_shade(friendly, ble, home_key, dev, adv, probe=probe),
                 timeout=PER_SHADE_TIMEOUT,
             )
         except TimeoutError:
@@ -398,13 +557,29 @@ def main() -> int:
     parser.add_argument(
         "-v", "--verbose", action="store_true", help="Enable debug logging"
     )
+    parser.add_argument(
+        "--probe",
+        action="store_true",
+        help=(
+            "Sweep payload lengths for 0xF1DD/0xFFDD to find what the "
+            "firmware accepts.  Read-only; slow (one BLE round-trip per "
+            "length).  Share the output to help decode these opcodes."
+        ),
+    )
     args = parser.parse_args()
 
     targets: list[tuple[str, str]] | None = None
     if args.ble_name:
         targets = [(ble, ble) for ble in args.ble_name]
     return asyncio.run(
-        run(args.hub, targets, args.all, args.scan_timeout, args.verbose)
+        run(
+            args.hub,
+            targets,
+            args.all,
+            args.scan_timeout,
+            args.verbose,
+            probe=args.probe,
+        )
     )
 
 

--- a/scripts/shade_report.py
+++ b/scripts/shade_report.py
@@ -1,0 +1,412 @@
+"""Standalone debug report for PowerView BLE shade(s).
+
+Talks directly to the shade over BLE (AES-CTR + GATT), with no coupling
+to the Home Assistant integration code. Fetches the shade's homekey
+from a G3 Gateway, scans for the BLE advertisement, then dumps:
+  1. BLE advertisement (raw + decoded)
+  2. Standard GATT device-info characteristics
+  3. Read-only PowerView queries:
+       - 0xF1DD product info
+       - 0xFFDD HW diagnostics (contains serial / firmware / type / model)
+       - 0xFFDE power status (battery vs. hardwired)
+
+Dependencies:  bleak, bleak-retry-connector, cryptography, requests  (no HA)
+
+SAFETY: only the three read-only opcodes above are ever sent. No
+set/move/scene/rekey/factory-reset opcodes are implemented here.
+
+Usage:
+    python scripts/shade_report.py --ble-name PV-XXXXXX
+    python scripts/shade_report.py --all
+    python scripts/shade_report.py --all --hub http://hub.local -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+# Allow "python scripts/shade_report.py" (the documented invocation) to resolve
+# the sibling package import below: we prepend the project root to sys.path so
+# `scripts.extract_gateway3_homekey` is importable regardless of CWD.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import json
+import logging
+import struct
+from typing import Any, Self
+
+from bleak import BleakClient, BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import AdvertisementData
+from bleak.uuids import normalize_uuid_str
+from bleak_retry_connector import establish_connection
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+import requests
+
+from scripts.extract_gateway3_homekey import HUB, get_shade_key
+
+# --- PowerView BLE protocol ---------------------------------------
+MFCT_ID = 2073  # Hunter Douglas BLE manufacturer identifier
+UUID_TX = "cafe1001-c0ff-ee01-8000-a110ca7ab1e0"
+UUID_COV_SERVICE = normalize_uuid_str("fdc1")
+UUID_DEV_SERVICE = normalize_uuid_str("180a")
+
+# Standard GATT Device Information Service characteristics
+GATT_DEV_INFO: list[tuple[str, str]] = [
+    ("manufacturer", "2a29"),
+    ("model", "2a24"),
+    ("serial_nr", "2a25"),
+    ("hw_rev", "2a27"),
+    ("fw_rev", "2a26"),
+    ("sw_rev", "2a28"),
+]
+
+# Read-only protocol queries ONLY. Never add opcodes that mutate state
+# (e.g. 0x01F7 move, 0xFA5A set-scene, 0xFB02 rekey, 0xFFDF set-power-
+# type, 0xFFEE factory-reset).
+#
+# Observed (fw_rev=22, Duette type 6, hardwired):
+#   0xF1DD → 1-byte `04` payload.  Possibly erroring (err code 4 =
+#            Invalid Length) or this firmware genuinely returns a stub.
+#   0xFFDD → 1-byte `04` payload.  Same caveat as F1DD.
+#   0xFFDE → 8-byte payload `XX 01 pp ?? ?? ?? tt 00` where:
+#              byte 0 (XX) = power type — 0 = hardwired (confirmed);
+#                            1 = battery, 2 = rechargeable (hypothesis,
+#                            unconfirmed — file firmware lacks a
+#                            non-hardwired shade to sample).
+#              byte 2 (pp) = position %
+#              byte 6 (tt) = shade type_id (matches advertisement byte 2)
+#            0xFFDE is the reliable source for battery-vs-hardwired
+#            detection.  The advertisement's 2-bit level field maxes at
+#            3 ("100% or hardwired") and cannot disambiguate the two.
+GET_QUERIES: list[tuple[int, str]] = [
+    (0xF1DD, "product info"),
+    (0xFFDD, "HW diagnostics"),
+    (0xFFDE, "power status"),
+]
+
+POWER_LEVELS = {4: 100, 3: 100, 2: 50, 1: 20, 0: 0}
+
+SCAN_TIMEOUT = 30.0
+CMD_TIMEOUT = 30.0
+GATEWAY_TIMEOUT = 30
+
+
+# --- Gateway shade list --------------------------------------------
+def fetch_shade_list(hub: str) -> list[dict[str, Any]]:
+    """Return the list of shades registered with the G3 gateway."""
+    resp = requests.get(f"{hub}/home/shades", timeout=GATEWAY_TIMEOUT)
+    resp.raise_for_status()
+    return json.loads(resp.content)
+
+
+# --- BLE advertisement decode --------------------------------------
+def decode_adv(manuf: bytes) -> dict[str, Any] | None:
+    """Decode the 9-byte V2 advertisement payload."""
+    if len(manuf) != 9:
+        return None
+    flags = manuf[3] & 0x3
+    pos = ((manuf[4] & 0x0F) << 6) | ((manuf[3] >> 2) & 0x3F)
+    pos2 = (manuf[5] << 4) + (manuf[4] >> 4)
+    level_bits = (manuf[8] >> 6) & 0x3
+    return {
+        "home_id": int.from_bytes(manuf[0:2], "little"),
+        "type_id": manuf[2],
+        "position": pos / 10,
+        "position2": pos2 >> 2,
+        "position3": manuf[6],
+        "tilt": manuf[7],
+        "opening": flags == 0x2,
+        "closing": flags == 0x1,
+        "charging_flag": flags == 0x3,
+        "level_bits": level_bits,
+        "level_pct": POWER_LEVELS.get(level_bits, "?"),
+    }
+
+
+# --- BLE scanner helper --------------------------------------------
+async def find_shades(
+    names: set[str], timeout: float
+) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
+    """Scan once, return the first advertisement seen for each named shade."""
+    loop = asyncio.get_running_loop()
+    results: dict[str, tuple[BLEDevice, AdvertisementData]] = {}
+    done = asyncio.Event()
+
+    def detected(dev: BLEDevice, adv: AdvertisementData) -> None:
+        if dev.name in names and dev.name not in results:
+            results[dev.name] = (dev, adv)
+            if len(results) == len(names):
+                loop.call_soon_threadsafe(done.set)
+
+    scanner = BleakScanner(detection_callback=detected)
+    await scanner.start()
+    try:
+        await asyncio.wait_for(done.wait(), timeout=timeout)
+    except TimeoutError:
+        pass
+    finally:
+        await scanner.stop()
+    return results
+
+
+# --- Minimal PowerView BLE client ----------------------------------
+class PowerViewClient:
+    """Talks the PowerView BLE protocol.
+
+    Wire format (TX and RX, both encrypted with AES-128-CTR, IV = 16 zero
+    bytes, key = the shade's homekey):
+
+        byte 0..1  command        (little-endian uint16)
+        byte 2     sequence       (TX: incremented; RX: echoed from TX)
+        byte 3     payload length
+        byte 4..   payload
+
+    Both write and notify happen on the same UUID_TX characteristic.
+    """
+
+    def __init__(self, device: BLEDevice, home_key: bytes) -> None:
+        """Store connection parameters; actual connect happens in __aenter__."""
+        self.device = device
+        self.client = BleakClient(device)
+        self.home_key = home_key
+        self.seq = 1
+        self._rx: bytes = b""
+        self._rx_event = asyncio.Event()
+
+    async def __aenter__(self) -> Self:
+        """Connect over BLE and subscribe to the TX characteristic."""
+        # establish_connection (bleak_retry_connector) retries automatically on
+        # transient WinRT errors and weak-signal cancellations, which plain
+        # BleakClient.connect() surfaces as TimeoutError.  The services= filter
+        # tells the stack which GATT services to enumerate, speeding discovery
+        # on marginal links.  Mirrors the integration's connect path in api.py.
+        self.client = await establish_connection(
+            BleakClient,
+            self.device,
+            self.device.name or "shade",
+            max_attempts=3,
+            services=[UUID_COV_SERVICE, UUID_DEV_SERVICE],
+        )
+        await self.client.start_notify(UUID_TX, self._on_notify)
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Disconnect best-effort; errors here are not actionable."""
+        with contextlib.suppress(Exception):
+            await self.client.disconnect()
+
+    def _aes(self) -> Cipher[modes.CTR]:
+        return Cipher(algorithms.AES(self.home_key), modes.CTR(bytes(16)))
+
+    def _on_notify(self, _sender: object, data: bytearray) -> None:
+        dec = self._aes().decryptor()
+        self._rx = dec.update(bytes(data)) + dec.finalize()
+        self._rx_event.set()
+
+    async def read_gatt(self, uuid: str) -> bytes:
+        """Read a standard GATT characteristic by 16-bit UUID."""
+        return bytes(await self.client.read_gatt_char(normalize_uuid_str(uuid)))
+
+    async def query(self, cmd: int, data: bytes = b"") -> bytes:
+        """Send a read-only command, return the response payload."""
+        # cmd is packed BIG-endian so the wire bytes appear in the order the
+        # shade expects: wire byte 0 = high byte of opcode, byte 1 = low byte.
+        # GET_QUERIES uses the emulator's case-label naming (0xF1DD, 0xFFDD,
+        # 0xFFDE), where byte 0 = 0xF1/0xFF and byte 1 = 0xDD/0xDE. The
+        # integration enum (api.py) uses pre-byte-swapped values with
+        # little-endian packing to reach the same wire bytes; here we keep
+        # the emulator naming and byte-swap at pack time instead.
+        tx = struct.pack(">HBB", cmd, self.seq, len(data)) + data
+        enc = self._aes().encryptor()
+        tx_enc = enc.update(tx) + enc.finalize()
+        self.seq = (self.seq + 1) & 0xFF
+        self._rx_event.clear()
+        await self.client.write_gatt_char(UUID_TX, tx_enc, response=False)
+        await asyncio.wait_for(self._rx_event.wait(), timeout=CMD_TIMEOUT)
+        if len(self._rx) < 4:
+            raise ValueError(f"Response too short: {self._rx.hex(' ')}")
+        payload_len = self._rx[3]
+        return self._rx[4 : 4 + payload_len]
+
+
+# --- Report rendering ----------------------------------------------
+def _section(title: str) -> None:
+    print(f"\n  {title}")
+    print(f"  {'-' * len(title)}")
+
+
+async def report_shade(
+    friendly_name: str,
+    ble_name: str,
+    home_key: bytes,
+    device: BLEDevice | None,
+    adv: AdvertisementData | None,
+) -> None:
+    """Print the full report for a single shade: advertisement + GATT + queries."""
+    print(f"\n=== '{friendly_name}'  (BLE: {ble_name}) ===")
+
+    _section("1. BLE advertisement")
+    if device is None or adv is None:
+        print("  not seen on air within scan window — skipping BLE queries")
+        return
+    print(f"  address:  {device.address}")
+    print(f"  rssi:     {adv.rssi} dBm")
+    manuf = adv.manufacturer_data.get(MFCT_ID, b"")
+    print(f"  raw:      {manuf.hex(' ') if manuf else '(none)'}")
+    decoded = decode_adv(manuf)
+    if decoded:
+        print(f"  home_id:  0x{decoded['home_id']:04x}")
+        print(f"  type_id:  {decoded['type_id']}")
+        print(
+            f"  position: {decoded['position']}  "
+            f"pos2={decoded['position2']}  pos3={decoded['position3']}  "
+            f"tilt={decoded['tilt']}"
+        )
+        print(
+            f"  flags:    opening={decoded['opening']}  "
+            f"closing={decoded['closing']}  "
+            f"charging_flag={decoded['charging_flag']}"
+        )
+        print(
+            f"  level:    bits={decoded['level_bits']} "
+            f"(→ {decoded['level_pct']}%; cannot report hardwired=4)"
+        )
+
+    async with PowerViewClient(device, home_key) as api:
+        _section("2. GATT device info")
+        for key, uuid in GATT_DEV_INFO:
+            try:
+                value = (await api.read_gatt(uuid)).decode("utf-8", errors="replace")
+                print(f"  {key:13} {value}")
+            except Exception as ex:  # noqa: BLE001
+                print(f"  {key:13} <error: {ex}>")
+
+        _section("3. Protocol queries (read-only)")
+        for cmd, label in GET_QUERIES:
+            try:
+                payload = await api.query(cmd)
+                print(
+                    f"  0x{cmd:04X} {label:16} "
+                    f"({len(payload):2} B): {payload.hex(' ')}"
+                )
+            except Exception as ex:  # noqa: BLE001
+                print(f"  0x{cmd:04X} {label:16} FAILED — {ex}")
+                break
+
+
+# --- Main ----------------------------------------------------------
+PER_SHADE_TIMEOUT = 45.0  # hard cap on total time spent per shade's report
+
+
+async def run(
+    hub: str,
+    targets: list[tuple[str, str]] | None,
+    all_shades: bool,
+    scan_timeout: float,
+    verbose: bool,
+) -> int:
+    """Fetch the shade list, homekey, then report on each target."""
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    # Always fetch the hub's full shade list: we need it regardless of
+    # whether targets came from --all or --ble-name, because the homekey
+    # fetch should use whichever shade the hub sees strongest, not
+    # necessarily one the user happens to be targeting locally.
+    print(f"Fetching shade list from {hub}...")
+    try:
+        shades = fetch_shade_list(hub)
+    except Exception as ex:  # noqa: BLE001
+        print(f"  failed: {ex}")
+        return 1
+    print(f"  found {len(shades)} shade(s)")
+
+    if all_shades:
+        targets = [
+            (base64.b64decode(s["name"]).decode("utf-8"), s["bleName"])
+            for s in shades
+        ]
+    assert targets is not None
+
+    # Homekey is network-wide — fetch once from any shade the hub can
+    # reach.  Try the hub's strongest-signal shades first to avoid
+    # burning the 10s timeout on one that's currently unreachable.
+    key_candidates = sorted(
+        shades, key=lambda s: s.get("signalStrength", -100), reverse=True
+    )
+    print(f"\nFetching homekey from {hub} (one-time for the home)...")
+    home_key: bytes | None = None
+    for s in key_candidates:
+        ble = s["bleName"]
+        sig = s.get("signalStrength", "?")
+        try:
+            home_key = get_shade_key(hub, ble)
+            print(f"  got it via {ble} (hub signal {sig}): {home_key.hex()}")
+            break
+        except Exception as ex:  # noqa: BLE001
+            print(f"  {ble} (hub signal {sig}): {ex} — trying next shade...")
+    if home_key is None:
+        print("Could not fetch homekey from any shade. Aborting.")
+        return 1
+
+    name_set = {ble for _, ble in targets}
+    print(
+        f"\nScanning for {len(name_set)} shade(s) "
+        f"(up to {scan_timeout:.0f}s; tap a hardwired shade if not seen)..."
+    )
+    seen = await find_shades(name_set, scan_timeout)
+    print(f"  {len(seen)}/{len(name_set)} visible on air")
+
+    for friendly, ble in targets:
+        dev, adv = seen.get(ble, (None, None))
+        # Per-shade timeout so one unreachable shade can't stall the whole run.
+        try:
+            await asyncio.wait_for(
+                report_shade(friendly, ble, home_key, dev, adv),
+                timeout=PER_SHADE_TIMEOUT,
+            )
+        except TimeoutError:
+            print(f"  (shade {ble} exceeded {PER_SHADE_TIMEOUT:.0f}s — skipping)")
+    return 0
+
+
+def main() -> int:
+    """Parse CLI args and dispatch to the async report runner."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hub", default=HUB, help=f"Gateway URL (default: {HUB})")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--ble-name",
+        action="append",
+        help="BLE name of a shade (repeatable), e.g. 'PV-XXXXXX'",
+    )
+    group.add_argument(
+        "--all", action="store_true", help="Report on every shade known to the gateway"
+    )
+    parser.add_argument(
+        "--scan-timeout",
+        type=float,
+        default=SCAN_TIMEOUT,
+        help=f"BLE scan timeout in seconds (default: {SCAN_TIMEOUT})",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable debug logging"
+    )
+    args = parser.parse_args()
+
+    targets: list[tuple[str, str]] | None = None
+    if args.ble_name:
+        targets = [(ble, ble) for ble in args.ble_name]
+    return asyncio.run(
+        run(args.hub, targets, args.all, args.scan_timeout, args.verbose)
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What is this?

This PR introduces a **hub-based model** for managing PowerView BLE shades. A single config entry represents your PowerView home, and shades are discovered automatically over BLE.

## What this PR changes

### Architecture — hub-based setup
You set up the integration once — point it at your hub (or enter the key manually) — and shades are picked up automatically as they're discovered over BLE. New shades appear without any additional config. Friendly names come from the hub so they match what you see in the PowerView app.

- **`__init__.py`** — manages a collection of coordinators (one per shade), registers a BLE callback for new shades, and fetches metadata (names, `powerType`) from the hub API
- **`config_flow.py`** — a single setup step: choose how to provide the home key (fetch from hub, enter manually, or skip)
- **Entity platforms** — dispatcher pattern so entities are created for both existing and newly-discovered shades
- **One config entry** for the whole home; areas and device naming work cleanly with multiple shades

### Shade support
- **Capability detection** (`ShadeCapability` in `api.py`) drives which entities get created per shade — top-down, TDBU, duolite, tilt-on-closed
- **Top-down shades** — dedicated cover entity with inverted position logic (SkyLift-style)
- **Tilt-on-closed shades** — dedicated cover entity for types 18 and 44 (tilt only available when fully closed)
- **Vertical blinds** — type 54 support (Vertical Slats, Left Stack), plus the rest of the official `aio-powerview-api` shade-type table
- **Velocity control** — new `number.py` entity for shades that support velocity
- **Hardwired vs battery** — `query_power_type` over BLE; battery sensors are hidden on hardwired shades, and the spurious `battery_charging` control lock has been removed
- Bit-addressing fix that PR #16 was trying to address, without breaking other shades
- Position bit extraction fix that prevents `pos2` contamination on TDBU shades

### Reliability & UX
- Strongest-signal shade is tried first when fetching the home key
- Single discovery notification for all blinds (instead of one per shade)
- Stale BLE device handling
- New `scripts/shade_report.py` diagnostic tool that dumps shade bytes/metadata for debugging unsupported types

Closes #3
Closes #8
Closes #21
Closes #27
